### PR TITLE
Make Invaders More Agressive

### DIFF
--- a/creep.action.invading.js
+++ b/creep.action.invading.js
@@ -47,38 +47,44 @@ action.newTarget = function(creep){
 
     if( !flag.room.controller || !flag.room.controller.my ) {        
         //attack healer
-        var target = creep.pos.findClosestByRange(creep.room.hostiles, {
+        var target = creep.pos.findClosestByRange(creep.room.enemies, {
             function(hostile){ return _.some(hostile.body, {'type': HEAL}); } 
         });
-        if( target ) 
+        if( target ) {
             return target;
+        }
         //attack attacker
-        target = creep.pos.findClosestByRange(creep.room.hostiles, {
+        target = creep.pos.findClosestByRange(creep.room.enemies, {
             function(hostile){ return _.some(hostile.body, function(part){return part.type == ATTACK || part.type == RANGED_ATTACK}); } 
         });
-        if( target ) 
+        if( target ) {
             return target;
-  
+        }
+        
         // attack tower
-       target = creep.pos.findClosestByPath(FIND_HOSTILE_STRUCTURES, {
+        target = creep.pos.findClosestByPath(FIND_HOSTILE_STRUCTURES, {
             filter: (structure) => {
                 return structure.structureType == STRUCTURE_TOWER;
             }
         });
-        if( target ) 
+        if( target ) {
             return target;
+        }
+
         // attack remaining creeps
-        target = creep.pos.findClosestByRange(creep.room.hostiles);
-        if( target ) 
-            return target;        
+        target = creep.pos.findClosestByRange(creep.room.enemies);
+        if( target ) {
+            return target;
+        }
         // attack spawn
         target = creep.pos.findClosestByPath(FIND_HOSTILE_STRUCTURES, {
             filter: (structure) => {
                 return structure.structureType == STRUCTURE_SPAWN;
             }
         });
-        if( target ) 
-            return target;        
+        if( target ) { 
+            return target;
+        }
         // attack structures
         target = creep.pos.findClosestByPath(FIND_HOSTILE_STRUCTURES, {
             filter : (structure) => {

--- a/room.js
+++ b/room.js
@@ -409,6 +409,24 @@ var mod = {
                     return this._hostileIds;
                 }
             },
+           'enemies': {
+                configurable: true,
+                get: function() {
+                    if( _.isUndefined(this._enemies) ){ 
+                        this._enemies = this.find(FIND_CREEPS, { filter : c => _.indexOf(PLAYER_WHITELIST, c.owner.username) == -1 });
+                    }
+                    return this._enemies;
+                }
+            },
+            'enemyIds': {
+                configurable: true,
+                get: function() {
+                    if( _.isUndefined(this._enemyIds) ){ 
+                        this._enemyIds = _.map(this.enemies, 'id');
+                    }
+                    return this._enemyIds;
+                }
+            },
             'combatCreeps': {
                 configurable: true,
                 get: function() {


### PR DESCRIPTION
It seemed to me that invading creeps would only attack creeps that
attacked them (what I understand to be the hostile creeps).  When
performing an invasion I felt it would be better to have then attack
anything that is not a white-list player's.  This will include creeps
that cannot attack (such as miners, claimers and upgraders) which helps
keep contested rooms free.