### PR TITLE
provide class-like inheritance to static mixins

### DIFF
--- a/global.js
+++ b/global.js
@@ -1,9 +1,9 @@
 var mod = {
     init: function(params){
         // Load extension functions
-        Creep.extend = load("creep").extend;
-        Room.extend = load("room").extend;
-        Spawn.extend = load("spawn").extend;
+        Creep.extend = load("creep", Creep).extend;
+        Room.extend = load("room", Room).extend;
+        Spawn.extend = load("spawn", Spawn).extend;
         // make params available globally
         _.assign(global, params);
         // Add more stuff to global

--- a/main.js
+++ b/main.js
@@ -1,5 +1,19 @@
 /* https://github.com/ScreepsOCS/screeps.behaviour-action-pattern */
 
+function looseBindAll(thisArg, keys) {
+    const iterKeys = keys ? keys : _.keys(thisArg);
+
+    for (const fn of iterKeys) {
+        if (typeof thisArg[fn] === "function") {
+            const original = thisArg[fn];
+            thisArg[fn] = thisArg[fn].bind(thisArg);
+            thisArg[fn].unbound = original;
+        }
+    }
+
+    return thisArg;
+}
+
 module.exports.loop = function () {
     // ensure required memory namespaces
     if (Memory.modules === undefined) 
@@ -68,7 +82,7 @@ module.exports.loop = function () {
             // override, _.create preserves mod as the __proto__
             if( viralOverride ) {
                 mod = _.create(mod, viralOverride);
-                if( bindAll ) mod = _.bindAll(mod, _.keys(viralOverride));
+                if( bindAll ) mod = looseBindAll(mod, _.keys(viralOverride));
             }
             // cleanup
             else delete Memory.modules[namespace][modName];
@@ -91,7 +105,7 @@ module.exports.loop = function () {
         }
         if( mod ) {
             if( prototype ) {
-                mod = _.bindAll(_.create(prototype, mod), _.keys(mod));
+                mod = looseBindAll(_.create(prototype, mod), _.keys(mod));
             }
             // load viral overrides
             mod = infect(mod, 'internalViral', modName, !!prototype);


### PR DESCRIPTION
example `viral.room.js`

```
module.exports = {
    extend: function(){
        Object.getPrototypeOf(this).extend.unbound.apply(this);

        Object.defineProperties(Room.prototype, {
            // additional Room.prototype properties
        }
    }
};
```

The prototype chain continues all the way until the value provided by load (in this case Room). That way all static members of Room are also available via `this` inside the module (so that API objects and OCS objects behave similarly).