### PR TITLE
Creep.onError and Creep.actionError event

### DIFF
--- a/creep.Action.js
+++ b/creep.Action.js
@@ -53,11 +53,11 @@ var Action = function(actionName){
         if( range <= this.targetRange ) {
             var workResult = this.work(creep);
             if( workResult != OK ) {
-                if( DEBUG ) logErrorCode(creep, workResult);
-                delete creep.data.actionName;
-                delete creep.data.targetId;
+                const tryAction = creep.action;
+                const tryTarget = creep.target;
                 creep.action = null;
                 creep.target = null;
+                creep.onError(this, creep.target, workResult);
                 return;
             }
         }

--- a/creep.Action.js
+++ b/creep.Action.js
@@ -57,7 +57,7 @@ var Action = function(actionName){
                 const tryTarget = creep.target;
                 creep.action = null;
                 creep.target = null;
-                creep.onError(this, creep.target, workResult);
+                creep.handleError({errorCode: workResult, action: this, target: creep.target, range, creep});
                 return;
             }
         }

--- a/creep.action.claiming.js
+++ b/creep.action.claiming.js
@@ -43,9 +43,7 @@ action.step = function(creep){
     if( range <= this.targetRange ) {
         var workResult = this.work(creep);
         if( workResult != OK ) {
-            if( DEBUG ) logErrorCode(creep, workResult);
-            delete creep.data.actionName;
-            delete creep.data.targetId;
+            creep.onError(this, creep.target, workResult);
         }
     }
     creep.drive( creep.target.pos, this.reachedRange, this.targetRange, range );

--- a/creep.action.claiming.js
+++ b/creep.action.claiming.js
@@ -43,7 +43,7 @@ action.step = function(creep){
     if( range <= this.targetRange ) {
         var workResult = this.work(creep);
         if( workResult != OK ) {
-            creep.onError(this, creep.target, workResult);
+            creep.handleError({errorCode: workResult, action: this, target: creep.target, range, creep});
         }
     }
     creep.drive( creep.target.pos, this.reachedRange, this.targetRange, range );

--- a/creep.action.reserving.js
+++ b/creep.action.reserving.js
@@ -37,9 +37,7 @@ action.step = function(creep){
     if( range <= this.targetRange ) {
         var workResult = this.work(creep);
         if( workResult != OK ) {
-            if( DEBUG ) logErrorCode(creep, workResult);
-            delete creep.data.actionName;
-            delete creep.data.targetId;
+            creep.onError(this, creep.target, workResult);
         }
     }
     creep.drive( creep.target.pos, this.reachedRange, this.targetRange, range );

--- a/creep.action.reserving.js
+++ b/creep.action.reserving.js
@@ -37,7 +37,7 @@ action.step = function(creep){
     if( range <= this.targetRange ) {
         var workResult = this.work(creep);
         if( workResult != OK ) {
-            creep.onError(this, creep.target, workResult);
+            creep.handleError({errorCode: workResult, action: this, target: creep.target, range, creep});
         }
     }
     creep.drive( creep.target.pos, this.reachedRange, this.targetRange, range );

--- a/creep.action.upgrading.js
+++ b/creep.action.upgrading.js
@@ -27,9 +27,7 @@ action.step = function(creep){
     if( range <= this.targetRange ) {
         var workResult = this.work(creep);
         if( workResult != OK ) {
-            if( DEBUG ) logErrorCode(creep, workResult);
-            delete creep.data.actionName;
-            delete creep.data.targetId;
+            creep.onError(this, creep.target, workResult);
         }
     }
     creep.drive( creep.target.pos, this.reachedRange, this.targetRange, range );

--- a/creep.action.upgrading.js
+++ b/creep.action.upgrading.js
@@ -27,7 +27,7 @@ action.step = function(creep){
     if( range <= this.targetRange ) {
         var workResult = this.work(creep);
         if( workResult != OK ) {
-            creep.onError(this, creep.target, workResult);
+            creep.handleError({errorCode: workResult, action: this, target: creep.target, range, creep});
         }
     }
     creep.drive( creep.target.pos, this.reachedRange, this.targetRange, range );

--- a/creep.js
+++ b/creep.js
@@ -28,6 +28,9 @@ var mod = {
             reallocating:load("creep.action.reallocating"),
             recycling:load("creep.action.recycling")
         };
+        for (const action in Creep.action) {
+            if (Creep.action[action].register) Creep.action[action].register(this);
+        }
         Creep.behaviour = {
             claimer: load("creep.behaviour.claimer"),
             hauler: load("creep.behaviour.hauler"),
@@ -41,6 +44,9 @@ var mod = {
             upgrader: load("creep.behaviour.upgrader"),
             worker: load("creep.behaviour.worker")
         };
+        for (const behaviour in Creep.behaviour) {
+            if (Creep.behaviour[behaviour].register) Creep.behaviour[behaviour].register(this);
+        }
         Creep.setup = {
             claimer: load("creep.setup.claimer"),
             hauler: load("creep.setup.hauler"),
@@ -54,6 +60,9 @@ var mod = {
             upgrader: load("creep.setup.upgrader"),
             worker: load("creep.setup.worker")
         };
+        for (const setup in Creep.setup) {
+            if (Creep.setup[setup].register) Creep.setup[setup].register(this);
+        }
         Creep.loop = function(){
             var run = creep => creep.run();
             _.forEach(Game.creeps, run);
@@ -422,6 +431,21 @@ var mod = {
                 }
             }
         });
+
+        Creep.prototype.onError = function(tryAction, tryTarget, workResult) {
+            debugger;
+            if (this.resolvingError) return;
+
+            this.resolvingError = tryAction;
+            Creep.actionError.trigger({creep: this, tryAction, tryTarget, workResult});
+
+            if (this.resolvingError) {
+                if (DEBUG) logErrorCode(this, workResult);
+                delete this.data.actionName;
+                delete this.data.targetId;
+                delete this.resolvingError;
+            }
+        };
     }
 }
 

--- a/creep.js
+++ b/creep.js
@@ -433,7 +433,6 @@ var mod = {
         });
 
         Creep.prototype.onError = function(tryAction, tryTarget, workResult) {
-            debugger;
             if (this.resolvingError) return;
 
             this.resolvingError = tryAction;

--- a/creep.js
+++ b/creep.js
@@ -28,9 +28,6 @@ var mod = {
             reallocating:load("creep.action.reallocating"),
             recycling:load("creep.action.recycling")
         };
-        for (const action in Creep.action) {
-            if (Creep.action[action].register) Creep.action[action].register(this);
-        }
         Creep.behaviour = {
             claimer: load("creep.behaviour.claimer"),
             hauler: load("creep.behaviour.hauler"),
@@ -44,9 +41,6 @@ var mod = {
             upgrader: load("creep.behaviour.upgrader"),
             worker: load("creep.behaviour.worker")
         };
-        for (const behaviour in Creep.behaviour) {
-            if (Creep.behaviour[behaviour].register) Creep.behaviour[behaviour].register(this);
-        }
         Creep.setup = {
             claimer: load("creep.setup.claimer"),
             hauler: load("creep.setup.hauler"),
@@ -60,9 +54,6 @@ var mod = {
             upgrader: load("creep.setup.upgrader"),
             worker: load("creep.setup.worker")
         };
-        for (const setup in Creep.setup) {
-            if (Creep.setup[setup].register) Creep.setup[setup].register(this);
-        }
         Creep.loop = function(){
             var run = creep => creep.run();
             _.forEach(Game.creeps, run);
@@ -117,6 +108,18 @@ var mod = {
             body.forEach(evaluatePart);
             return threat;
         }
+
+        Creep.register = function() {
+            for (const action in Creep.action) {
+                if (Creep.action[action].register) Creep.action[action].register(this);
+            }
+            for (const behaviour in Creep.behaviour) {
+                if (Creep.behaviour[behaviour].register) Creep.behaviour[behaviour].register(this);
+            }
+            for (const setup in Creep.setup) {
+                if (Creep.setup[setup].register) Creep.setup[setup].register(this);
+            }
+        };
 
         // Check if a creep has body parts of a certain type anf if it is still active. 
         // Accepts a single part type (like RANGED_ATTACK) or an array of part types. 

--- a/creep.js
+++ b/creep.js
@@ -435,17 +435,22 @@ var mod = {
             }
         });
 
-        Creep.prototype.onError = function(tryAction, tryTarget, workResult) {
-            if (this.resolvingError) return;
+        // errorData = {errorCode, action, target, ...}
+        Creep.prototype.handleError = function(errorData) {
+            if (Creep.resolvingError) return;
 
-            this.resolvingError = tryAction;
-            Creep.actionError.trigger({creep: this, tryAction, tryTarget, workResult});
+            this.resolvingError = errorData;
+            errorData.preventDefault = function() {
+                Creep.resolvingError = null;
+            };
 
-            if (this.resolvingError) {
-                if (DEBUG) logErrorCode(this, workResult);
+            Creep.error.trigger(errorData);
+
+            if (Creep.resolvingError) {
+                if (DEBUG) logErrorCode(this, errorData.errorCode);
                 delete this.data.actionName;
                 delete this.data.targetId;
-                delete this.resolvingError;
+                Creep.resolvingError = null;
             }
         };
     }

--- a/extensions.js
+++ b/extensions.js
@@ -26,6 +26,10 @@ var mod = {
         // param: creep name
         Creep.died = new LiteEvent();
 
+        // after a creep action fails
+        // param: {creep, tryAction, tryTarget, workResult}
+        Creep.actionError = new LiteEvent();
+
         // ocurrs when a new invader has been spotted for the first time
         // param: invader creep
         Room.newInvader = new LiteEvent();

--- a/extensions.js
+++ b/extensions.js
@@ -26,9 +26,9 @@ var mod = {
         // param: creep name
         Creep.died = new LiteEvent();
 
-        // after a creep action fails
+        // after a creep error
         // param: {creep, tryAction, tryTarget, workResult}
-        Creep.actionError = new LiteEvent();
+        Creep.error = new LiteEvent();
 
         // ocurrs when a new invader has been spotted for the first time
         // param: invader creep

--- a/main.js
+++ b/main.js
@@ -125,6 +125,8 @@ module.exports.loop = function () {
     // use a viral.global.js module to implement your own custom function
     if( glob.custom ) glob.custom();
 
+    // Register setup / behaviour / action hooks.
+    Creep.register();
     // Register task hooks
     Task.register();
 


### PR DESCRIPTION
This change consolidates most action errors into `Creep.prototype.onError(tryAction, tryTarget, errorCode)`

Additionally the event Creep.actionError is raised and event listeners should signal that the error was recovered and should not be logged by calling `delete creep.resolvingError`

Example implementation: https://github.com/karlthepagan/screeps.behaviour-action-pattern/commit/60aff5612a6cf88c23327023838552625d69d53d