### PR TITLE
fix maxCount based on flags

### DIFF
--- a/creep.setup.melee.js
+++ b/creep.setup.melee.js
@@ -2,22 +2,7 @@ var setup = new Creep.Setup('melee');
 setup.minControllerLevel = 2;
 setup.globalMeasurement = true;
 setup.measureByHome = true;
-setup.maxCount = function(room){
-    let maxRange = 2;
-    let max = 0;
-    let distance, flag;
-    let calcMax = flagEntry => {
-        distance = routeRange(room.name, flagEntry.roomName);
-        if( distance > maxRange )
-            return;
-        flag = Game.flags[flagEntry.name];
-        if( !flag.targetOf || flag.targetOf.length == 0 )
-            max++;
-    }
-    let flagEntries = FlagDir.filter(FLAG_COLOR.defense);
-    flagEntries.forEach(calcMax);
-    return max;
-};
+setup.maxCount = Creep.Setup.maxPerFlag(FLAG_COLOR.defense, 2, setup.measureByHome);
 setup.small = {
     fixedBody: [MOVE, HEAL],
     multiBody: [MOVE, ATTACK],

--- a/creep.setup.ranger.js
+++ b/creep.setup.ranger.js
@@ -2,22 +2,7 @@ var setup = new Creep.Setup('ranger');
 setup.minControllerLevel = 4;
 setup.globalMeasurement = true;
 setup.measureByHome = true;
-setup.maxCount = function(room){
-    let maxRange = 2;
-    let max = 0;
-    let distance, flag;
-    let calcMax = flagEntry => {
-        distance = routeRange(room.name, flagEntry.roomName);
-        if( distance > maxRange )
-            return;
-        flag = Game.flags[flagEntry.name];
-        if( !flag.targetOf || flag.targetOf.length == 0 )
-            max++;
-    }
-    let flagEntries = FlagDir.filter(FLAG_COLOR.defense);
-    flagEntries.forEach(calcMax);
-    return max;
-};
+setup.maxCount = Creep.Setup.maxPerFlag(FLAG_COLOR.defense, 2, setup.measureByHome);
 setup.small = {
     fixedBody: [RANGED_ATTACK,MOVE,RANGED_ATTACK,MOVE,HEAL,MOVE],
     multiBody: [RANGED_ATTACK, MOVE],

--- a/global.js
+++ b/global.js
@@ -3,10 +3,7 @@ var mod = {
         //console.log('base');
     },
     init: function(params){
-        // Load extension functions
-        Creep.extend = load("creep").extend;
-        Room.extend = load("room").extend;
-        Spawn.extend = load("spawn").extend;
+        // START LOCAL REFERENCES ONLY
         // make params available globally
         _.assign(global, params);
         // Add more stuff to global
@@ -28,12 +25,6 @@ var mod = {
                     this.handlers.slice(0).forEach(h => h(data)); 
                 }
             },
-            // load modules
-            Extensions: load("extensions"),
-            Population: load("population"),
-            FlagDir: load("flagDir"),
-            Task: load("task"),
-            Tower: load("tower"),
             // Flag colors, used throughout the code
             FLAG_COLOR: {
                 invade: { // destroy everything enemy in the room
@@ -284,6 +275,21 @@ var mod = {
                     return v.toString(16);
                 });
             }
+        });
+        // END LOCAL REFERENCES ONLY
+
+        // Load extension functions
+        Creep.extend = load("creep").extend;
+        Room.extend = load("room").extend;
+        Spawn.extend = load("spawn").extend;
+
+        _.assign(global, {
+            // load modules
+            Extensions: load("extensions"),
+            Population: load("population"),
+            FlagDir: load("flagDir"),
+            Task: load("task"),
+            Tower: load("tower"),
         });
     }
 }


### PR DESCRIPTION
this fixes the issue where all flag-based spawns come in waves

this was non-trivial... so it also adds Creep.Setup.debugType. With DEBUG enabled, set Creep.Setup.debugType = Creep.setup.ranger.type in order to see the valid setup decisions printed.