### PR TITLE
Fix for feeding.

### DIFF
--- a/creep.action.feeding.js
+++ b/creep.action.feeding.js
@@ -11,7 +11,7 @@ action.isAddableAction = function(creep){
 };
 action.isAddableTarget = function(target){
     return ( target.my &&
-        (!target.targetOf || target.targetOf.length < this.maxPerTarget));
+        (!target.targetOf || _.filter(target.targetOf, {'actionName':'feeding'}).length < this.maxPerTarget));
 };
 action.newTarget = function(creep){
     var that = this;


### PR DESCRIPTION
"spawn".targetOf can be recycling action. When creeps are recycling, haulers and workers won't feed energy to the spawn.