### PR TITLE
hotfix cannot read property of undefined

### DIFF
--- a/spawn.js
+++ b/spawn.js
@@ -15,8 +15,12 @@ mod.extend = function(){
         // old spawning system 
         let that = this;
         let probe = setup => {
-            return setup.isValidSetup(room) && that.createCreepBySetup(setup);
-        }
+            try {
+                return setup.isValidSetup(room) && that.createCreepBySetup(setup);
+            } catch(e) {
+                return false;
+            }
+        };
 
         let busy = this.createCreepByQueue(room.spawnQueueHigh);
         // don't spawn lower if there is one waiting in the higher queue 


### PR DESCRIPTION
```TypeError: Cannot read property 'isValidSetup' of undefined
    at probe (spawn:18:25)
    at arraySome (/opt/engine/node_modules/lodash/index.js:1493:13)
    at Function.some (/opt/engine/node_modules/lodash/index.js:7051:14)
    at Spawn.execute (spawn:24:22)
    at run (spawn:109:33)
    at baseForOwn (/opt/engine/node_modules/lodash/index.js:2046:14)
    at Function.<anonymous> (/opt/engine/node_modules/lodash/index.js:3346:13)```

this is a hotfix that makes sure this error won't happen