### PR TITLE
Add Clear Spawn Queue Examples To commands.js

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -18,7 +18,7 @@ Game.rooms['<roomName>'].spawnQueueLow.push({parts:[MOVE,WORK,CARRY],name:'max',
 // clear low priority queue
 Memory.rooms['<roomName>'].spawnQueueLow = [0];
 // clear medium priority queue
-Memory.rooms['<roomName>'].spawnQueueMed = [0];
+Memory.rooms['<roomName>'].spawnQueueMedium = [0];
 // clear high priority queue 
 Memory.rooms['<roomName>'].spawnQueueHigh = [0];
 

--- a/commands.js
+++ b/commands.js
@@ -14,6 +14,14 @@ Game.spawns['<spawnName>'].createCreepBySetup(Creep.setup.worker);
 // or
 Game.rooms['<roomName>'].spawnQueueLow.push({parts:[MOVE,WORK,CARRY],name:'max',setup:'worker'});
 
+// clear spawn queues for a room
+// clear low priority queue
+Game.rooms['<roomName>'].spawnQueueLow = [0];
+// clear medium priority queue
+Game.rooms['<roomName>'].spawnQueueMed = [0];
+// clear high priority queue 
+Game.rooms['<roomName>'].spawnQueueHigh = [0];
+
 // move Creep
 Game.creeps['<creepName>'].move(RIGHT);
 

--- a/commands.js
+++ b/commands.js
@@ -16,11 +16,11 @@ Game.rooms['<roomName>'].spawnQueueLow.push({parts:[MOVE,WORK,CARRY],name:'max',
 
 // clear spawn queues for a room
 // clear low priority queue
-Game.rooms['<roomName>'].spawnQueueLow = [0];
+Memory.rooms['<roomName>'].spawnQueueLow = [0];
 // clear medium priority queue
-Game.rooms['<roomName>'].spawnQueueMed = [0];
+Memory.rooms['<roomName>'].spawnQueueMed = [0];
 // clear high priority queue 
-Game.rooms['<roomName>'].spawnQueueHigh = [0];
+Memory.rooms['<roomName>'].spawnQueueHigh = [0];
 
 // move Creep
 Game.creeps['<creepName>'].move(RIGHT);


### PR DESCRIPTION
When the code gets stuck it is helpful to clear the command queues.  These examples will clear each level of queue in a room. 

This patch was mentioned in issue #525.