### PR TITLE
Require 200 Energy To Spawn A Worker

### DIFF
--- a/creep.setup.worker.js
+++ b/creep.setup.worker.js
@@ -59,7 +59,7 @@ setup.RCL = {
     5: {
         fixedBody: [],
         multiBody: [CARRY, WORK, MOVE],
-        minAbsEnergyAvailable: 400,
+        minAbsEnergyAvailable: 200,
         minEnergyAvailable: room => setup.hasMinerOrHauler(room) ? 0.3 : 0,
         maxMulti: 8,
         maxCount: room => setup.maxWorker(room),
@@ -68,7 +68,7 @@ setup.RCL = {
     6: {
         fixedBody: [],
         multiBody: [CARRY, WORK, MOVE],
-        minAbsEnergyAvailable: 600,
+        minAbsEnergyAvailable: 200,
         minEnergyAvailable: room => setup.hasMinerOrHauler(room) ? 0.3 : 0,
         maxMulti: 8,
         maxCount: room => setup.maxWorker(room),
@@ -77,7 +77,7 @@ setup.RCL = {
     7: {
         fixedBody: [],
         multiBody: [CARRY, WORK, MOVE],
-        minAbsEnergyAvailable: 800,
+        minAbsEnergyAvailable: 200,
         minEnergyAvailable: room => setup.hasMinerOrHauler(room) ? 0.2 : 0,
         maxMulti: 10,
         maxCount: room => setup.maxWorker(room),
@@ -86,7 +86,7 @@ setup.RCL = {
     8: {
         fixedBody: [],
         multiBody: [CARRY, WORK, MOVE],
-        minAbsEnergyAvailable: 800,
+        minAbsEnergyAvailable: 200,
         minEnergyAvailable: room => setup.hasMinerOrHauler(room) ? 0.1 : 0,
         maxMulti: room => (( !room.storage || room.storage.energy > MAX_STORAGE_ENERGY[8] ) ? 16 : 10),
         maxCount: room => setup.maxWorker(room),


### PR DESCRIPTION
When a room collapses you can only safely assume that there is 0 energy in the extension and 0 energy in the spawn. The game will give you a full spawn of energy after a while and from this life can resume.  We should always be able to spawn a worker to drive room recovery with that 200 energy.  

This is a simple fix for issue #614 Must Always Be Able To Build A Worker With 200 Energy.  

It could be improved by making the minimum energy level required to spawn a worker dependent on the population of the room.  If there are other workers or haulers in the room, we could use the higher level.  This would ensure larger workers are always made at higher levels unless a population collapse has happened.  The advantage of this change is that it is simple, it works and it solves the issue this second.