### PR TITLE
Feature/remote hauler capacity

### DIFF
--- a/creep.behaviour.remoteMiner.js
+++ b/creep.behaviour.remoteMiner.js
@@ -121,7 +121,11 @@ mod.mine = function(creep) {
 mod.approach = function(creep){
     let targetPos = new RoomPosition(creep.data.determinatedSpot.x, creep.data.determinatedSpot.y, creep.data.destiny.room);
     let range = creep.pos.getRangeTo(targetPos);
-    if( range > 0 )
+    if( range > 0 ) {
         creep.drive( targetPos, 0, 0, range );
+        if( range === 1 && !creep.data.predictedRenewal ) {
+            creep.data.predictedRenewal = _.min([500, 1500 - creep.ticksToLive + creep.data.spawningTime]);
+        }
+    }
     return range;
 };

--- a/creep.behaviour.remoteMiner.js
+++ b/creep.behaviour.remoteMiner.js
@@ -24,7 +24,7 @@ mod.mine = function(creep) {
     let source;
     if( !creep.data.determinatedTarget ) { // select source
         let notDeterminated = source => {
-            let hasThisSource = data => { return data.determinatedTarget == source.id };
+            let hasThisSource = data => { return data.determinatedTarget == source.id && data.ttl > 100 };
             let existingBranding = _.find(Memory.population, hasThisSource);
             return !existingBranding;
         };

--- a/global.js
+++ b/global.js
@@ -189,7 +189,25 @@ mod.trace = function (category, entityWhere, ...message) {
     if (!( Memory.debugTrace[category] === true || _(entityWhere).reduce(reduceMemoryWhere, 1) === true )) return;
     if (Memory.debugTrace.no && _(entityWhere).pairs().some(noMemoryWhere) === true) return;
 
-    console.log(Game.time, dye(CRAYON.error, category), ...message, dye(CRAYON.birth, JSON.stringify(entityWhere)));
+    let msg = message;
+    let key = '';
+    if (message.length === 0 && category) {
+        let leaf = category;
+        do {
+            key = leaf;
+            leaf = entityWhere[leaf];
+        } while( entityWhere[leaf] && leaf != category);
+
+        if (leaf && leaf != category) {
+            if (typeof leaf === 'string') {
+                msg = [leaf];
+            } else {
+                msg = [key, '=', leaf];
+            }
+        }
+    }
+
+    console.log(Game.time, dye(CRAYON.error, category), ...msg, dye(CRAYON.birth, JSON.stringify(entityWhere)));
 };
 // log some text as "system message" showing a "referrer" as label
 mod.logSystem = function(roomName, message) {

--- a/parameter.js
+++ b/parameter.js
@@ -86,7 +86,8 @@ let mod = {
     COST_MATRIX_VALIDITY: 1000,
     CONTROLLER_SIGN: false,
     CONTROLLER_SIGN_MESSAGE: "Territory of the Open Collaboration Society! (https://github.com/ScreepsOCS)",
-    REMOTE_HAULER_MULTIPLIER: 1, // Number of haulers spawned per source in a remote mining room.
+    REMOTE_HAULER_MULTIPLIER: 1, // Max number of haulers spawned per source in a remote mining room.
+    REMOTE_HAULER_REHOME: false, // May haulers choose closer storage for delivery?
     REMOTE_WORKER_MULTIPLIER: 1, // Number of workers spawned per remote mining room.
     PLAYER_WHITELIST: ['cyberblast','SirLovi','Asku','Kazume','Noxeth','MrDave','Telemac','Xephael','Zoiah','fsck-u','FaceWound','forkmantis','Migaaresno','xAix1999','silentpoots','arguinyano','OokieCookie','OverlordQ','Nibinhilion','Crowsbane','Yew','BogdanBiv','s1akr','Pandabear41','Logmadr','Patrik','novice','Conquest','ofirl','GeorgeBerkeley','TTR','tynstar','K-C','Hoekynl','Sunri5e','AgOrange','distantcam','Lisp','bbdMinimbl'],
     // Don't attack. Must be a member of OCS for permanent whitelisting in git repository. But you can change your own copy... Please ask if you are interested in joining OCS :)

--- a/parameter.js
+++ b/parameter.js
@@ -88,6 +88,7 @@ let mod = {
     CONTROLLER_SIGN_MESSAGE: "Territory of the Open Collaboration Society! (https://github.com/ScreepsOCS)",
     REMOTE_HAULER_MULTIPLIER: 1, // Max number of haulers spawned per source in a remote mining room.
     REMOTE_HAULER_REHOME: false, // May haulers choose closer storage for delivery?
+    REMOTE_HAULER_MIN_WEIGHT: 800, // Small haulers are a CPU drain.
     REMOTE_WORKER_MULTIPLIER: 1, // Number of workers spawned per remote mining room.
     PLAYER_WHITELIST: ['cyberblast','SirLovi','Asku','Kazume','Noxeth','MrDave','Telemac','Xephael','Zoiah','fsck-u','FaceWound','forkmantis','Migaaresno','xAix1999','silentpoots','arguinyano','OokieCookie','OverlordQ','Nibinhilion','Crowsbane','Yew','BogdanBiv','s1akr','Pandabear41','Logmadr','Patrik','novice','Conquest','ofirl','GeorgeBerkeley','TTR','tynstar','K-C','Hoekynl','Sunri5e','AgOrange','distantcam','Lisp','bbdMinimbl'],
     // Don't attack. Must be a member of OCS for permanent whitelisting in git repository. But you can change your own copy... Please ask if you are interested in joining OCS :)

--- a/task.js
+++ b/task.js
@@ -46,7 +46,7 @@ mod.spawn = (creepDefinition, destiny, roomParams, onQueued) => {
     if( !room ) return null;
     // define new creep
     if(!destiny) destiny = {};
-    destiny.room = roomParams.targetRoom;
+    if(!destiny.room && roomParams.targetRoom) destiny.room = roomParams.targetRoom;
 
     let parts = Creep.compileBody(room, creepDefinition);
 


### PR DESCRIPTION
This is a very basic capacity-based hauler spawning:

documentation linked from the tuning page:
https://github.com/ScreepsOCS/screeps.behaviour-action-pattern/wiki/Settings-&-Tuning#3-task-settings


### Quick Start
**viral.parameters.js**
This effectively unlocks the capacity feature.
```
    REMOTE_HAULER_MULTIPLIER: 4,
    REMOTE_HAULER_REHOME: true,
```

**commands**
This changes the carry capacity by the number of carry parts built to fill the route. Stored in task memory. -20 removes the full capacity for 1 source 1 room away, -40 to remove 1 source 2 rooms away. Positive numbers add more carry parts. Negative numbers remove carry parts. Repeat the command to continue changing the balance number.

This waits for the next spawning cycle. A higher hauler multiplier may be needed to achieve the number of needed parts.
```
Task.mining.carry('E48N81', -10)
```