### PR TITLE
Set Reserver Priority To Low

### DIFF
--- a/task.reserve.js
+++ b/task.reserve.js
@@ -6,7 +6,8 @@ mod.creep = {
         fixedBody: [CLAIM, CLAIM, MOVE, MOVE],
         multiBody: [],
         name: "reserver", 
-        behaviour: "claimer"
+        behaviour: "claimer",
+        queue: "Low"
     },
 };
 // hook into events


### PR DESCRIPTION
Reservers are cheaper to build than many pioneers or remote miners.  This can lead to remote rooms that are being exploited or mined getting filled with reservers who do not generate revenue, rather that creeps or do.  Get some cash first, then worry about the chance of getting more cash.  

Reservers are cheaper than some haulers and workers too.  If they are on the medium priority queue then the reserver might get generated first.  This could be very bad as a main room without any workers or haulers can quickly grind to a halt.  

This change makes the generation or reservers a low priority spawn, as already happens for claimers.  

This may go some way to addressing #614 Must Always Be Able To Build A Worker With 200 Energy; where it seems that sometimes a new worker is never generated.  It might help reduce the chances of a level 6 room collapse too as #525 documented for two rooms.  The exact causes of that are unknown though.