### PR TITLE
Change/pioneer build first

### DIFF
--- a/creep.behaviour.pioneer.js
+++ b/creep.behaviour.pioneer.js
@@ -44,7 +44,8 @@ mod.nextAction = function(creep) {
                     _.forEach(FlagDir.filter(FLAG_COLOR.invade.exploit, spawnFlag.pos, true), remove);
                 }
                 else { // no spawn => build it
-                    if( flag.room.constructionSites.length == 0 ) // no constructionSites // TODO: filter for spawn-constructionSite
+                    let spawnSite = flag.room.constructionSites.some(s => s.structureType === STRUCTURE_SPAWN);
+                    if( !spawnSite ) // no spawn construction site yet
                         flag.room.createConstructionSite(spawnFlag, STRUCTURE_SPAWN); // create spawn construction site
                 }
             }

--- a/creep.behaviour.worker.js
+++ b/creep.behaviour.worker.js
@@ -40,17 +40,45 @@ mod.nextAction = function(creep){
                 Creep.action.repairing,
                 Creep.action.idle];
         } else {
-            priority = [
-                Creep.action.repairing,
-                Creep.action.feeding,
-                Creep.action.building,
-                Creep.action.fueling,
-                Creep.action.fortifying,
-                Creep.action.charging,
-                Creep.action.upgrading,
-                Creep.action.storing,
-                Creep.action.picking,
-                Creep.action.idle];
+            if (creep.data.creepType === "pioneer") { // prioritize building for pioneers, upgrade to RCL2 first
+                if (creep.room.controller && creep.room.controller.level < 2) {
+                    priority = [
+                        Creep.action.feeding,
+                        Creep.action.upgrading,
+                        Creep.action.building,
+                        Creep.action.repairing,
+                        Creep.action.fueling,
+                        Creep.action.fortifying,
+                        Creep.action.charging,
+                        Creep.action.storing,
+                        Creep.action.picking,
+                        Creep.action.idle];
+                } else {
+                    priority = [
+                        Creep.action.feeding,
+                        Creep.action.building,
+                        Creep.action.repairing,
+                        Creep.action.fueling,
+                        Creep.action.fortifying,
+                        Creep.action.charging,
+                        Creep.action.upgrading,
+                        Creep.action.storing,
+                        Creep.action.picking,
+                        Creep.action.idle];
+                }
+            } else {
+                priority = [
+                    Creep.action.repairing,
+                    Creep.action.feeding,
+                    Creep.action.building,
+                    Creep.action.fueling,
+                    Creep.action.fortifying,
+                    Creep.action.charging,
+                    Creep.action.upgrading,
+                    Creep.action.storing,
+                    Creep.action.picking,
+                    Creep.action.idle];
+            }
         }
         if( creep.room.relativeEnergyAvailable < 1 && (!creep.room.population || !creep.room.population.typeCount['hauler'] || creep.room.population.typeCount['hauler'] < 1 || !creep.room.population.typeCount['miner'] || creep.room.population.typeCount['miner'] < 1) ) {
             priority.unshift(Creep.action.feeding);


### PR DESCRIPTION
Change Pioneers to upgrade to lv 2 first and get us a safe mode, then to prioritize building over repairing in case we are acquiring a room that already has some walls.  Also they now set the spawn correctly if there are other construction sites in the room (as long as there isn't a spawn construction site yet).