### PR TITLE
Fix when no creeps remain and large cost creep is in queue.

### DIFF
--- a/spawn.js
+++ b/spawn.js
@@ -51,7 +51,7 @@ mod.extend = function(){
         }
         // wait with spawning until enough resources are available
         if (cost > this.room.remainingEnergyAvailable) {
-            if (cost > this.room.energyCapacityAvailable) {
+            if (cost > this.room.energyCapacityAvailable || (cost > 300 && !this.room.creeps.length)) {
                 global.logSystem(this.pos.roomName, dye(CRAYON.error, 'Queued creep too big for room: ' + JSON.stringify(params) ));
                 return false;
             }

--- a/spawn.js
+++ b/spawn.js
@@ -51,7 +51,7 @@ mod.extend = function(){
         }
         // wait with spawning until enough resources are available
         if (cost > this.room.remainingEnergyAvailable) {
-            if (cost > this.room.energyCapacityAvailable || (cost > 300 && !this.room.creeps.length)) {
+            if (cost > this.room.energyCapacityAvailable || (cost >= 300 && !this.room.creeps.length)) {
                 global.logSystem(this.pos.roomName, dye(CRAYON.error, 'Queued creep too big for room: ' + JSON.stringify(params) ));
                 return false;
             }


### PR DESCRIPTION
If a room gets wiped, and a large cost worker is left in the queue, it gets stuck.  No point waiting for enough resources when they aren’t coming!