### PR TITLE
added build nearby for remote haulers with range 1 to Creep.repairNearby

### DIFF
--- a/creep.behaviour.remoteMiner.js
+++ b/creep.behaviour.remoteMiner.js
@@ -82,7 +82,9 @@ mod.mine = function(creep) {
 
         if( creep.data.determinatedSpot ) {
             let carrying = creep.sum;
-            if( source.link && source.link.energy < source.link.energyCapacity ) {
+            if( source.energy == 0) {
+                Creep.behaviour.worker.run(creep);
+            } else if( source.link && source.link.energy < source.link.energyCapacity ) {
                 if(CHATTY) creep.say('harvesting', SAY_PUBLIC);
                 let range = this.approach(creep);
                 if( range == 0 ){

--- a/creep.js
+++ b/creep.js
@@ -310,16 +310,19 @@ mod.extend = function(){
         // if it has energy and a work part
         if(this.carry.energy > 0 && this.hasActiveBodyparts(WORK)) {
             let nearby = this.pos.findInRange(this.room.structures.repairable, 3);
-            if( nearby && nearby.length > 0 ){
+            if( nearby ){
                 if( DEBUG && TRACE ) trace('Creep', {creepName:this.name, Action:'repairing', Creep:'repairNearby'}, nearby[0].pos);
                 this.repair(nearby[0]);
             } else {
                 if( DEBUG && TRACE ) trace('Creep', {creepName:this.name, Action:'repairing', Creep:'repairNearby'}, 'none');
                 // enable remote haulers to build their own roads and containers
-                if( this.data && this.data.creepType == 'remoteHauler' ) {
+                if( REMOTE_HAULER_DRIVE_BY_BUILDING && this.data && this.data.creepType == 'remoteHauler' ) {
                     // only search in a range of 1 to save cpu
-                    let nearby = this.pos.findInRange(this.room.constructionSites, 1);
-                    if( nearby && nearby.length > 0 ){
+                    let nearby = this.pos.findInRange(this.room.constructionSites, 1, {filter: (site) =>{
+                        return site.structureType == STRUCTURE_CONTAINER ||
+					site.structureType == STRUCTURE_ROAD;
+                    }});
+                    if( nearby ){
                         if( DEBUG && TRACE ) trace('Creep', {creepName:this.name, Action:'building', Creep:'buildNearby'}, nearby[0].pos);
                         this.build(nearby[0]);
                     } else {

--- a/creep.js
+++ b/creep.js
@@ -310,7 +310,7 @@ mod.extend = function(){
         // if it has energy and a work part
         if(this.carry.energy > 0 && this.hasActiveBodyparts(WORK)) {
             let nearby = this.pos.findInRange(this.room.structures.repairable, 3);
-            if( nearby ){
+            if( nearby && nearby.length ){
                 if( DEBUG && TRACE ) trace('Creep', {creepName:this.name, Action:'repairing', Creep:'repairNearby'}, nearby[0].pos);
                 if( this.repair(nearby[0]) == OK && this.carry.energy <= this.getActiveBodyparts(WORK) * REPAIR_POWER / REPAIR_COST ) {
                     Creep.action.idle.assign(this);
@@ -324,11 +324,11 @@ mod.extend = function(){
                             (site.structureType == STRUCTURE_CONTAINER ||
                             site.structureType == STRUCTURE_ROAD);
                     }});
-                    if( nearby ){
+                    if( nearby && nearby.length ){
                         if( DEBUG && TRACE ) trace('Creep', {creepName:this.name, Action:'building', Creep:'buildNearby'}, nearby[0].pos);
                         if( this.build(nearby[0]) == OK && this.carry.energy <= this.getActiveBodyparts(WORK) * BUILD_POWER ) {
                             Creep.action.idle.assign(this);
-                        };
+                        }
                     } else {
                         if( DEBUG && TRACE ) trace('Creep', {creepName:this.name, Action:'building', Creep:'buildNearby'}, 'none');
                     }

--- a/creep.js
+++ b/creep.js
@@ -314,7 +314,8 @@ mod.extend = function(){
                 if( DEBUG && TRACE ) trace('Creep', {creepName:this.name, Action:'repairing', Creep:'repairNearby'}, nearby[0].pos);
                 if( this.repair(nearby[0]) == OK && this.carry.energy <= this.getActiveBodyparts(WORK) * REPAIR_POWER / REPAIR_COST ) {
                     Creep.action.idle.assign(this);
-                };            } else {
+                };
+            } else {
                 if( DEBUG && TRACE ) trace('Creep', {creepName:this.name, Action:'repairing', Creep:'repairNearby'}, 'none');
                 // enable remote haulers to build their own roads and containers
                 if( REMOTE_HAULER_DRIVE_BY_BUILDING && this.data && this.data.creepType == 'remoteHauler' ) {

--- a/creep.js
+++ b/creep.js
@@ -312,7 +312,7 @@ mod.extend = function(){
             let nearby = this.pos.findInRange(this.room.structures.repairable, 3);
             if( nearby && nearby.length ){
                 if( DEBUG && TRACE ) trace('Creep', {creepName:this.name, Action:'repairing', Creep:'repairNearby'}, nearby[0].pos);
-                if( this.repair(nearby[0]) == OK && this.carry.energy <= this.getActiveBodyparts(WORK) * REPAIR_POWER / REPAIR_COST ) {
+                if( this.repair(nearby[0]) == OK && this.carry.energy <= this.getActiveBodyparts(WORK) * REPAIR_POWER * REPAIR_COST ) {
                     Creep.action.idle.assign(this);
                 }
             } else {

--- a/creep.js
+++ b/creep.js
@@ -319,8 +319,9 @@ mod.extend = function(){
                 if( REMOTE_HAULER_DRIVE_BY_BUILDING && this.data && this.data.creepType == 'remoteHauler' ) {
                     // only search in a range of 1 to save cpu
                     let nearby = this.pos.findInRange(this.room.constructionSites, 1, {filter: (site) =>{
-                        return site.structureType == STRUCTURE_CONTAINER ||
-					site.structureType == STRUCTURE_ROAD;
+                        return site.my && REMOTE_HAULER_DRIVE_BY_BUILD_ALL ||
+                            (site.structureType == STRUCTURE_CONTAINER ||
+                            site.structureType == STRUCTURE_ROAD);
                     }});
                     if( nearby ){
                         if( DEBUG && TRACE ) trace('Creep', {creepName:this.name, Action:'building', Creep:'buildNearby'}, nearby[0].pos);

--- a/creep.js
+++ b/creep.js
@@ -314,7 +314,7 @@ mod.extend = function(){
                 if( DEBUG && TRACE ) trace('Creep', {creepName:this.name, Action:'repairing', Creep:'repairNearby'}, nearby[0].pos);
                 if( this.repair(nearby[0]) == OK && this.carry.energy <= this.getActiveBodyparts(WORK) * REPAIR_POWER / REPAIR_COST ) {
                     Creep.action.idle.assign(this);
-                };
+                }
             } else {
                 if( DEBUG && TRACE ) trace('Creep', {creepName:this.name, Action:'repairing', Creep:'repairNearby'}, 'none');
                 // enable remote haulers to build their own roads and containers

--- a/creep.js
+++ b/creep.js
@@ -312,8 +312,9 @@ mod.extend = function(){
             let nearby = this.pos.findInRange(this.room.structures.repairable, 3);
             if( nearby ){
                 if( DEBUG && TRACE ) trace('Creep', {creepName:this.name, Action:'repairing', Creep:'repairNearby'}, nearby[0].pos);
-                this.repair(nearby[0]);
-            } else {
+                if( this.repair(nearby[0]) == OK && this.carry.energy <= this.getActiveBodyparts(WORK) * REPAIR_POWER / REPAIR_COST ) {
+                    Creep.action.idle.assign(this);
+                };            } else {
                 if( DEBUG && TRACE ) trace('Creep', {creepName:this.name, Action:'repairing', Creep:'repairNearby'}, 'none');
                 // enable remote haulers to build their own roads and containers
                 if( REMOTE_HAULER_DRIVE_BY_BUILDING && this.data && this.data.creepType == 'remoteHauler' ) {
@@ -325,7 +326,9 @@ mod.extend = function(){
                     }});
                     if( nearby ){
                         if( DEBUG && TRACE ) trace('Creep', {creepName:this.name, Action:'building', Creep:'buildNearby'}, nearby[0].pos);
-                        this.build(nearby[0]);
+                        if( this.build(nearby[0]) == OK && this.carry.energy <= this.getActiveBodyparts(WORK) * BUILD_POWER ) {
+                            Creep.action.idle.assign(this);
+                        };
                     } else {
                         if( DEBUG && TRACE ) trace('Creep', {creepName:this.name, Action:'building', Creep:'buildNearby'}, 'none');
                     }

--- a/creep.js
+++ b/creep.js
@@ -319,7 +319,7 @@ mod.extend = function(){
                 // enable remote haulers to build their own roads and containers
                 if( REMOTE_HAULER_DRIVE_BY_BUILDING && this.data && this.data.creepType == 'remoteHauler' ) {
                     // only search in a range of 1 to save cpu
-                    let nearby = this.pos.findInRange(this.room.constructionSites, 1, {filter: (site) =>{
+                    let nearby = this.pos.findInRange(this.room.constructionSites, REMOTE_HAULER_DRIVE_BY_BUILD_RANGE, {filter: (site) =>{
                         return site.my && REMOTE_HAULER_DRIVE_BY_BUILD_ALL ||
                             (site.structureType == STRUCTURE_CONTAINER ||
                             site.structureType == STRUCTURE_ROAD);

--- a/creep.js
+++ b/creep.js
@@ -315,6 +315,17 @@ mod.extend = function(){
                 this.repair(nearby[0]);
             } else {
                 if( DEBUG && TRACE ) trace('Creep', {creepName:this.name, Action:'repairing', Creep:'repairNearby'}, 'none');
+                // enable remote haulers to build their own roads and containers
+                if( this.data && this.data.creepType == 'remoteHauler' ) {
+                    // only search in a range of 1 to save cpu
+                    let nearby = this.pos.findInRange(this.room.constructionSites, 1);
+                    if( nearby && nearby.length > 0 ){
+                        if( DEBUG && TRACE ) trace('Creep', {creepName:this.name, Action:'building', Creep:'buildNearby'}, nearby[0].pos);
+                        this.build(nearby[0]);
+                    } else {
+                        if( DEBUG && TRACE ) trace('Creep', {creepName:this.name, Action:'building', Creep:'buildNearby'}, 'none');
+                    }
+                }
             }
         } else {
             if( DEBUG && TRACE ) trace('Creep', {creepName:this.name, Action:'repairing', Creep:'repairNearby'}, 'no WORK');

--- a/parameter.js
+++ b/parameter.js
@@ -103,4 +103,3 @@ let mod = {
     DEFENSE_BLACKLIST: [], // Don't defend those rooms (add room names). Blocks spawning via defense task (will not prevent offensive actions at all)
 }
 module.exports = mod;
-0000

--- a/parameter.js
+++ b/parameter.js
@@ -94,6 +94,7 @@ let mod = {
     REMOTE_HAULER_MULTIPLIER: 1, // Max number of haulers spawned per source in a remote mining room.
     REMOTE_HAULER_REHOME: false, // May haulers choose closer storage for delivery?
     REMOTE_HAULER_MIN_WEIGHT: 800, // Small haulers are a CPU drain.
+    REMOTE_HAULER_DRIVE_BY_BUILDING: false, // Allows remote haulers to build roads and containers. Consider setting REMOTE_WORKER_MULTIPLIER to 0.
     REMOTE_WORKER_MULTIPLIER: 1, // Number of workers spawned per remote mining room.
     PLAYER_WHITELIST: ['cyberblast','SirLovi','Asku','Kazume','Noxeth','MrDave','Telemac','Xephael','Zoiah','fsck-u','FaceWound','forkmantis','Migaaresno','xAix1999','silentpoots','arguinyano','OokieCookie','OverlordQ','Nibinhilion','Crowsbane','Yew','BogdanBiv','s1akr','Pandabear41','Logmadr','Patrik','novice','Conquest','ofirl','GeorgeBerkeley','TTR','tynstar','K-C','Hoekynl','Sunri5e','AgOrange','distantcam','Lisp','bbdMinimbl','Twill','Logxen','miR','Spedwards','Krazyfuq','Icesory','chobobobo','deft-code','mmmd','DKPlugins','pavelnieks'],
     // Don't attack. Must be a member of OCS for permanent whitelisting in git repository. But you can change your own copy... Please ask if you are interested in joining OCS :)

--- a/parameter.js
+++ b/parameter.js
@@ -95,7 +95,7 @@ let mod = {
     REMOTE_HAULER_REHOME: false, // May haulers choose closer storage for delivery?
     REMOTE_HAULER_MIN_WEIGHT: 800, // Small haulers are a CPU drain.
     REMOTE_HAULER_DRIVE_BY_BUILDING: false, // Allows remote haulers to build roads and containers. Consider setting REMOTE_WORKER_MULTIPLIER to 0.
-    REMOTE_HAULER_DRIVE_BY_BUILD_ALL: false, // If the above option is enabled then remote haulers will drive-by-build any of your structures.
+    REMOTE_HAULER_DRIVE_BY_BUILD_ALL: false, // If the above option is enabled then this option will allow remote haulers will drive-by-build any of your structures.
     REMOTE_WORKER_MULTIPLIER: 1, // Number of workers spawned per remote mining room.
     PLAYER_WHITELIST: ['cyberblast','SirLovi','Asku','Kazume','Noxeth','MrDave','Telemac','Xephael','Zoiah','fsck-u','FaceWound','forkmantis','Migaaresno','xAix1999','silentpoots','arguinyano','OokieCookie','OverlordQ','Nibinhilion','Crowsbane','Yew','BogdanBiv','s1akr','Pandabear41','Logmadr','Patrik','novice','Conquest','ofirl','GeorgeBerkeley','TTR','tynstar','K-C','Hoekynl','Sunri5e','AgOrange','distantcam','Lisp','bbdMinimbl','Twill','Logxen','miR','Spedwards','Krazyfuq','Icesory','chobobobo','deft-code','mmmd','DKPlugins','pavelnieks'],
     // Don't attack. Must be a member of OCS for permanent whitelisting in git repository. But you can change your own copy... Please ask if you are interested in joining OCS :)

--- a/parameter.js
+++ b/parameter.js
@@ -95,10 +95,12 @@ let mod = {
     REMOTE_HAULER_REHOME: false, // May haulers choose closer storage for delivery?
     REMOTE_HAULER_MIN_WEIGHT: 800, // Small haulers are a CPU drain.
     REMOTE_HAULER_DRIVE_BY_BUILDING: false, // Allows remote haulers to build roads and containers. Consider setting REMOTE_WORKER_MULTIPLIER to 0.
-    REMOTE_HAULER_DRIVE_BY_BUILD_ALL: false, // If the above option is enabled then this option will allow remote haulers will drive-by-build any of your structures.
+    REMOTE_HAULER_DRIVE_BY_BUILD_RANGE: 1, // A creep's max build distance is 3 but cpu can be saved by dropping the search distance to 1.
+    REMOTE_HAULER_DRIVE_BY_BUILD_ALL: false, // If REMOTE_HAULER_DRIVE_BY_BUILDING is enabled then this option will allow remote haulers will drive-by-build any of your structures.
     REMOTE_WORKER_MULTIPLIER: 1, // Number of workers spawned per remote mining room.
     PLAYER_WHITELIST: ['cyberblast','SirLovi','Asku','Kazume','Noxeth','MrDave','Telemac','Xephael','Zoiah','fsck-u','FaceWound','forkmantis','Migaaresno','xAix1999','silentpoots','arguinyano','OokieCookie','OverlordQ','Nibinhilion','Crowsbane','Yew','BogdanBiv','s1akr','Pandabear41','Logmadr','Patrik','novice','Conquest','ofirl','GeorgeBerkeley','TTR','tynstar','K-C','Hoekynl','Sunri5e','AgOrange','distantcam','Lisp','bbdMinimbl','Twill','Logxen','miR','Spedwards','Krazyfuq','Icesory','chobobobo','deft-code','mmmd','DKPlugins','pavelnieks'],
     // Don't attack. Must be a member of OCS for permanent whitelisting in git repository. But you can change your own copy... Please ask if you are interested in joining OCS :)
     DEFENSE_BLACKLIST: [], // Don't defend those rooms (add room names). Blocks spawning via defense task (will not prevent offensive actions at all)
 }
 module.exports = mod;
+0000

--- a/parameter.js
+++ b/parameter.js
@@ -95,6 +95,7 @@ let mod = {
     REMOTE_HAULER_REHOME: false, // May haulers choose closer storage for delivery?
     REMOTE_HAULER_MIN_WEIGHT: 800, // Small haulers are a CPU drain.
     REMOTE_HAULER_DRIVE_BY_BUILDING: false, // Allows remote haulers to build roads and containers. Consider setting REMOTE_WORKER_MULTIPLIER to 0.
+    REMOTE_HAULER_DRIVE_BY_BUILD_ALL: false, // If the above option is enabled then remote haulers will drive-by-build any of your structures.
     REMOTE_WORKER_MULTIPLIER: 1, // Number of workers spawned per remote mining room.
     PLAYER_WHITELIST: ['cyberblast','SirLovi','Asku','Kazume','Noxeth','MrDave','Telemac','Xephael','Zoiah','fsck-u','FaceWound','forkmantis','Migaaresno','xAix1999','silentpoots','arguinyano','OokieCookie','OverlordQ','Nibinhilion','Crowsbane','Yew','BogdanBiv','s1akr','Pandabear41','Logmadr','Patrik','novice','Conquest','ofirl','GeorgeBerkeley','TTR','tynstar','K-C','Hoekynl','Sunri5e','AgOrange','distantcam','Lisp','bbdMinimbl','Twill','Logxen','miR','Spedwards','Krazyfuq','Icesory','chobobobo','deft-code','mmmd','DKPlugins','pavelnieks'],
     // Don't attack. Must be a member of OCS for permanent whitelisting in git repository. But you can change your own copy... Please ask if you are interested in joining OCS :)


### PR DESCRIPTION
This small addition allows remote haulers to build their own roads and containers. It is implemented along with Creep.repairNearby and only searches for construction sites within a range of 1 to save cpu time. Depending on strategies this can make the remote worker superfluous. Experimenting can be done with setting the REMOTE_WORKER_MULTIPLIER in the parameter file to 0 to save on spawn time.