### PR TITLE
don't return error message when result of strategy handler is falsey

### DIFF
--- a/strategy.js
+++ b/strategy.js
@@ -10,7 +10,7 @@ mod.decorateAgent = function(prototype, ...definitions) {
         const currentStrategy = this.currentStrategy || this.strategy(ids);
         const returnValOrMethod = currentStrategy[method];
         const key = currentStrategy.key;
-        if (!returnValOrMethod) {
+        if (returnValOrMethod === undefined) {
             logError('no strategy handler', {agent: this.name || this.id, key, method, stack: new Error().stack});
             return;
         }
@@ -18,7 +18,7 @@ mod.decorateAgent = function(prototype, ...definitions) {
             return returnValOrMethod;
         }
         const returnVal = returnValOrMethod.apply(this.currentStrategy, args);
-        if (returnVal) {
+        if (returnVal !== undefined) {
             return returnVal;
         }
         logError('no strategy handler for args', {agent: this.name || this.id, key, method, args, stack: new Error().stack});


### PR DESCRIPTION
oops. found this while testing `change/pickingStrategy`

basically if you define a handler which returns a falsey value (rather than a function) it will return undefined and scream an error message

this isn't fatal, but it's far from ideal