### PR TITLE
strategy handler array arg from getStrategyHandler was producing a nested array

### DIFF
--- a/strategy.js
+++ b/strategy.js
@@ -32,7 +32,7 @@ mod.decorateAgent = function(prototype, ...definitions) {
         }
         return key;
     };
-    prototype.strategy = function(...ids) {
+    prototype.strategy = function(ids) {
         const key = this.strategyKey(ids);
 
         let strategy = mod.getCachedStrategy(this, key);


### PR DESCRIPTION
for example in this error message
```
error no strategy handler for args {"agent":"remoteHauler-betaOldMine-2","key":[["uncharging"],"remoteHauler","mining"],"method":"withdrawAmount","args":...,"stack":"Error\n    at prototype.getStrategyHandler (strategy:24:106)\n    at creep.action.uncharging:67:42\n    at Action.action.isValidTarget (creep.action.uncharging:9:12)\n    at Action.validateActionTarget (creep.Action:92:23)\n    at validateAssignment (population:233:39)\n    at /opt/engine/node_modules/lodash/index.js:3073:15\n    at baseForOwn (/opt/engine/node_modules/lodash/index.js:2046:14)\n    at /opt/engine/node_modules/lodash/index.js:3043:18\n    at Function. (/opt/engine/node_modules/lodash/index.js:3346:13)\n    at Object.mod.analyze (population:244:7)"}
```

The `key` in the trace should be `["uncharging","remoteHauler","mining"]` but it is `[["uncharging"],"remoteHauler","mining"]`