### PR TITLE
easier to understand undefined handler error, strategyName trace

### DIFF
--- a/strategy.js
+++ b/strategy.js
@@ -11,6 +11,7 @@ mod.decorateAgent = function(prototype, ...definitions) {
         const returnValOrMethod = currentStrategy[method];
         const strategyKey = currentStrategy.key;
         const strategyName = currentStrategy.name;
+        if (DEBUG && TRACE) trace('Strategy', {agent:this.name, strategyKey, strategyName, method});
         if (returnValOrMethod === undefined) {
             logError('strategy handler returned undefined', {agent: this.name || this.id, strategyKey, strategyName, method, stack: new Error().stack});
             return;

--- a/strategy.js
+++ b/strategy.js
@@ -9,9 +9,10 @@ mod.decorateAgent = function(prototype, ...definitions) {
     prototype.getStrategyHandler = function(ids, method, ...args) {
         const currentStrategy = this.currentStrategy || this.strategy(ids);
         const returnValOrMethod = currentStrategy[method];
-        const key = currentStrategy.key;
+        const strategyKey = currentStrategy.key;
+        const strategyName = currentStrategy.name;
         if (returnValOrMethod === undefined) {
-            logError('no strategy handler', {agent: this.name || this.id, key, method, stack: new Error().stack});
+            logError('strategy handler returned undefined', {agent: this.name || this.id, strategyKey, strategyName, method, stack: new Error().stack});
             return;
         }
         if (args.length === 0) {
@@ -21,7 +22,7 @@ mod.decorateAgent = function(prototype, ...definitions) {
         if (returnVal !== undefined) {
             return returnVal;
         }
-        logError('no strategy handler for args', {agent: this.name || this.id, key, method, args:args.toString(), stack: new Error().stack});
+        logError('handler returned undefined for args', {agent: this.name || this.id, strategyKey, strategyName, method, args:args.toString(), stack: new Error().stack});
     };
     prototype._strategyCache = {};
     prototype.strategyKey = function(ids) {


### PR DESCRIPTION
when strategy handlers accidentally return undef the cause of the complaint is not clear

this should make that better and also adds the strategyName to make this easier to triage