### PR TITLE
Pick harvest source based on distance first

### DIFF
--- a/creep.action.harvesting.js
+++ b/creep.action.harvesting.js
@@ -22,8 +22,9 @@ action.isAddableTarget = function(target, creep){
 action.newTarget = function(creep){
     let target = null;
     let sourceGuests = 999;
-    for( var iSource = 0; iSource < creep.room.sources.length; iSource++ ){
-        let source = creep.room.sources[iSource];
+    var roomSources = _.sortBy(creep.room.sources, s => creep.pos.getRangeTo(s))
+    for( var iSource = 0; iSource < roomSources.length; iSource++ ){
+        let source = roomSources[iSource];
         if( this.isValidTarget(source) && this.isAddableTarget(source, creep) ){
             if( source.targetOf === undefined ) {
                 sourceGuests = 0;

--- a/creep.action.harvesting.js
+++ b/creep.action.harvesting.js
@@ -22,7 +22,7 @@ action.isAddableTarget = function(target, creep){
 action.newTarget = function(creep){
     let target = null;
     let sourceGuests = 999;
-    var roomSources = _.sortBy(creep.room.sources, s => creep.pos.getRangeTo(s))
+    var roomSources = _.sortBy(creep.room.sources, s => creep.pos.getRangeTo(s));
     for( var iSource = 0; iSource < roomSources.length; iSource++ ){
         let source = roomSources[iSource];
         if( this.isValidTarget(source) && this.isAddableTarget(source, creep) ){


### PR DESCRIPTION
More of an issue on new rooms, looping niavely through list of sources can occassionally send creeps across room when a valid source is right next to them