### PR TITLE
avoid pioneer queue error

### DIFF
--- a/task.pioneer.js
+++ b/task.pioneer.js
@@ -73,7 +73,7 @@ mod.checkForRequiredCreeps = (flag) => {
             }, 
             { // spawn room selection params
                 targetRoom: flag.pos.roomName, 
-                minEnergyCapacity: 200, 
+                minEnergyCapacity: 400, // weight of fixedBody
                 rangeRclRatio: 2 // stronger preference of higher RCL rooms
             },
             creepSetup => { // callback onQueued


### PR DESCRIPTION
pioneers are queued for rooms that can't spawn them

```
Queued creep too big for room: {"parts":["work","work","carry","carry","move","move"],"name":"pioneer-pio3","behaviour":"pioneer","destiny":{"task":"pioneer","targetName":"pio3","flagName":"pio3","room":"E72S7"},"queueRoom":"E73S9"}
```