### PR TITLE
Stop remote miners and haulers from border cycling causing a mess.

### DIFF
--- a/creep.behaviour.miner.js
+++ b/creep.behaviour.miner.js
@@ -116,6 +116,12 @@ mod.run = function(creep) {
             } else {
                 Creep.behaviour.worker.run(creep);
             }
-        }
+        // move towards our source so we're ready to take over
+        } else if (creep.pos.getRangeTo(source) > 3) return Creep.action.travelling.assign(creep, source);
+    } else {
+        // move inside the room so we don't block the entrance
+        const flag = creep.data && creep.data.destiny ? Game.flags[creep.data.destiny.targetName] : null;
+        if (flag && creep.pos.getRangeTo(flag) > 3) Creep.action.travelling.assign(creep, flag);
     }
+    return Creep.action.idle.assign(creep);
 };

--- a/creep.behaviour.miner.js
+++ b/creep.behaviour.miner.js
@@ -121,7 +121,10 @@ mod.run = function(creep) {
     } else {
         // move inside the room so we don't block the entrance
         const flag = creep.data && creep.data.destiny ? Game.flags[creep.data.destiny.targetName] : null;
-        if (flag && creep.pos.getRangeTo(flag) > 3) Creep.action.travelling.assign(creep, flag);
+        if (flag && creep.pos.getRangeTo(flag) > 3) {
+            creep.moveTo(flag);
+            return Creep.action.travelling.assign(creep, flag);
+        }
     }
     return Creep.action.idle.assign(creep);
 };

--- a/creep.behaviour.remoteHauler.js
+++ b/creep.behaviour.remoteHauler.js
@@ -57,9 +57,8 @@ mod.nextAction = function(creep){
         if( this.assign(creep, Creep.action.uncharging) ) return;
         // if( this.assign(creep, Creep.action.robbing) ) return;
         if( this.assign(creep, Creep.action.picking) ) return;
-        // carrier full or everything picked
-        this.goHome(creep);
-        return;
+        // wait
+        return this.assign(creep, Creep.action.idle);
     }
     // somewhere
     else {

--- a/creep.behaviour.remoteHauler.js
+++ b/creep.behaviour.remoteHauler.js
@@ -58,9 +58,11 @@ mod.nextAction = function(creep){
         // if( this.assign(creep, Creep.action.robbing) ) return;
         if( this.assign(creep, Creep.action.picking) ) return;
         // wait
-        const flag = creep.data && creep.data.destiny ? Game.flags[creep.data.destiny.targetName] : null;
-        if (flag) return creep.moveTo(flag);
-        else return this.assign(creep, Creep.action.idle);
+        if ( creep.sum === 0 ) {
+            let source = creep.pos.findClosestByRange(creep.room.sources);
+            if (creep.room && source && creep.pos.getRangeTo(source) > 3) return Creep.action.travelling.assign(creep, source);
+        }
+        return this.assign(creep, Creep.action.idle);
     }
     // somewhere
     else {

--- a/creep.behaviour.remoteHauler.js
+++ b/creep.behaviour.remoteHauler.js
@@ -58,7 +58,9 @@ mod.nextAction = function(creep){
         // if( this.assign(creep, Creep.action.robbing) ) return;
         if( this.assign(creep, Creep.action.picking) ) return;
         // wait
-        return this.assign(creep, Creep.action.idle);
+        const flag = creep.data && creep.data.destiny ? Game.flags[creep.data.destiny.targetName] : null;
+        if (flag) return creep.moveTo(flag);
+        else return this.assign(creep, Creep.action.idle);
     }
     // somewhere
     else {

--- a/creep.behaviour.remoteHauler.js
+++ b/creep.behaviour.remoteHauler.js
@@ -60,7 +60,10 @@ mod.nextAction = function(creep){
         // wait
         if ( creep.sum === 0 ) {
             let source = creep.pos.findClosestByRange(creep.room.sources);
-            if (creep.room && source && creep.pos.getRangeTo(source) > 3) return Creep.action.travelling.assign(creep, source);
+            if (creep.room && source && creep.pos.getRangeTo(source) > 3) {
+                creep.moveTo(source);
+                return Creep.action.travelling.assign(creep, source);
+            }
         }
         return this.assign(creep, Creep.action.idle);
     }

--- a/creep.behaviour.remoteMiner.js
+++ b/creep.behaviour.remoteMiner.js
@@ -135,7 +135,7 @@ mod.mine = function(creep) {
                     creep.harvest(source);
                 }
             }
-        }
+        } else Creep.action.idle.assign(creep);
     }
 };
 mod.approach = function(creep){

--- a/creep.behaviour.remoteMiner.js
+++ b/creep.behaviour.remoteMiner.js
@@ -135,12 +135,14 @@ mod.mine = function(creep) {
                     creep.harvest(source);
                 }
             }
-        } else {
-            const flag = creep.data && creep.data.destiny ? Game.flags[creep.data.destiny.targetName] : null;
-            if (flag) return creep.moveTo(flag);
-            else return Creep.action.idle.assign(creep);
-        }
+        // move towards our source so we're ready to take over
+        } else if (creep.pos.getRangeTo(source) > 3) return Creep.action.travelling.assign(creep, source);
+    } else {
+        // move inside the room so we don't block the entrance
+        const flag = creep.data && creep.data.destiny ? Game.flags[creep.data.destiny.targetName] : null;
+        if (flag && creep.pos.getRangeTo(flag) > 3) Creep.action.travelling.assign(creep, flag);
     }
+    return Creep.action.idle.assign(creep);
 };
 mod.approach = function(creep){
     let targetPos = new RoomPosition(creep.data.determinatedSpot.x, creep.data.determinatedSpot.y, creep.data.destiny.room);

--- a/creep.behaviour.remoteMiner.js
+++ b/creep.behaviour.remoteMiner.js
@@ -135,7 +135,11 @@ mod.mine = function(creep) {
                     creep.harvest(source);
                 }
             }
-        } else Creep.action.idle.assign(creep);
+        } else {
+            const flag = creep.data && creep.data.destiny ? Game.flags[creep.data.destiny.targetName] : null;
+            if (flag) return creep.moveTo(flag);
+            else return Creep.action.idle.assign(creep);
+        }
     }
 };
 mod.approach = function(creep){


### PR DESCRIPTION
Quick fix to prevent border cycling.  @whardeman can you try this out to see if it resolves your issues.  Any larger implementation to your issues would not be appropriate for a merge into RC so this will have to do for now.