### PR TITLE
Fill up worker from containers when picking

### DIFF
--- a/creep.action.picking.js
+++ b/creep.action.picking.js
@@ -53,10 +53,10 @@ action.work = function(creep){
                 return result;
             }
         }
-        // Check for containers to uncharge also
+        // Check for containers to uncharge
         if( creep.sum < creep.carryCapacity) {
-            let containers = creep.pos.findInRange(creep.room.structures.container, 1, {
-               filter: (o) => Creep.action.uncharging.isAddableTarget(o, creep)
+            let containers = creep.pos.findInRange(creep.room.structures.container.in, 2, {
+               filter: (o) => Creep.action.uncharging.isValidTarget(o, creep)
             });
             if ( containers && containers.length > 0 ) {
                 Creep.action.uncharging.assign(creep, containers[0]);

--- a/creep.action.picking.js
+++ b/creep.action.picking.js
@@ -53,6 +53,16 @@ action.work = function(creep){
                 return result;
             }
         }
+        // Check for containers to uncharge also
+        if( creep.sum < creep.carryCapacity) {
+            let containers = creep.pos.findInRange(creep.room.structures.container, 1, {
+               filter: (o) => Creep.action.uncharging.isAddableTarget(o, creep)
+            });
+            if ( containers && containers.length > 0 ) {
+                Creep.action.uncharging.assign(creep, containers[0]);
+                return result;
+            }
+        }
         // unregister
         delete creep.data.actionName;
         delete creep.data.targetId;


### PR DESCRIPTION
I've noticed things picking up dropped energy waste ***a lot*** of time making back and forth trips to pick up a partial load of dropped energy/minerals. Then, instead of grabbing from the container to fill up and make room for more to be stored, they wander off, leaving the miners to have to drop more energy on the ground.