### PR TITLE
Fix upgrader determinatedSpot selection

### DIFF
--- a/creep.behaviour.upgrader.js
+++ b/creep.behaviour.upgrader.js
@@ -95,8 +95,13 @@ mod.run = function(creep) {
             if( creep.carry.energy <= carryThreshold ){
                 let store = _.find(creep.room.structures.links.controller, s => s.energy > 0 && creep.pos.isNearTo(s));
                 if( !store ) store = _.find(creep.room.structures.container.controller, s => s.store[RESOURCE_ENERGY] > 0 && creep.pos.isNearTo(s));
-                if( !store ) store = creep.room.storage && creep.room.storage.store[RESOURCE_ENERGY] > 0 && creep.pos.isNearTo(creep.room.storage);
-                if( !store ) store = creep.room.terminal && creep.room.terminal.store[RESOURCE_ENERGY] > 0 && creep.pos.isNearTo(creep.room.terminal);
+                if( !store ) {
+                    store = creep.room.storage && creep.room.storage.store[RESOURCE_ENERGY] > MIN_STORAGE_ENERGY[creep.room.controller.level] &&
+                        creep.pos.isNearTo(creep.room.storage);
+                }
+                if( !store ) {
+                    store = creep.room.terminal && creep.room.terminal.store[RESOURCE_ENERGY] > 0.5 * TERMINAL_ENERGY && creep.pos.isNearTo(creep.room.terminal);
+                }
                 if( store ) creep.withdraw(store, RESOURCE_ENERGY);
             }
             creep.controllerSign();

--- a/creep.behaviour.upgrader.js
+++ b/creep.behaviour.upgrader.js
@@ -43,9 +43,10 @@ mod.run = function(creep) {
                 };
                 spots = spots.concat(Room.fieldsInRange(args));
             };
-            if (creep.room.structures.container.controller) creep.room.structures.container.controller.forEach(getSpots);
             if (creep.room.structures.links.controller) creep.room.structures.links.controller.forEach(getSpots);
-            return spots;
+            if (spots.length) return spots; // prefer working next to a link
+            if (creep.room.structures.container.controller) creep.room.structures.container.controller.forEach(getSpots);
+            return spots; // containers are fine too
         };
         let spots = determineSpots();
         if( spots.length > 0 ){
@@ -82,8 +83,8 @@ mod.run = function(creep) {
         if( creep.room.controller && creep.pos.getRangeTo(creep.room.controller) <= 3){
             let carryThreshold = (creep.data.body&&creep.data.body.work ? creep.data.body.work : (creep.carryCapacity/2));
             if( creep.carry.energy <= carryThreshold ){
-                let store = creep.room.structures.links.controller.find(l => l.energy > 0);
-                if( !store ) store = creep.room.structures.container.controller.find(l => l.store.energy > 0);
+                let store = _.find(creep.room.structures.links.controller, s => s.energy > 0 && creep.pos.isNearTo(s));
+                if( !store ) store = _.find(creep.room.structures.container.controller, s => s.store[RESOURCE_ENERGY] > 0 && creep.pos.isNearTo(s));
                 if( store ) creep.withdraw(store, RESOURCE_ENERGY);
             }
             creep.controllerSign();

--- a/creep.behaviour.upgrader.js
+++ b/creep.behaviour.upgrader.js
@@ -26,6 +26,7 @@ mod.run = function(creep) {
     if( !creep.action ) Population.registerAction(creep, Creep.action.upgrading, creep.room.controller);
     if( !creep.data.determinatedSpot ) {
         let determineSpots = (ignoreSources=false) => {
+            let spots = [];
             let getSpots = s => {
                 let args = {
                     spots: [{
@@ -44,6 +45,7 @@ mod.run = function(creep) {
             };
             if (creep.room.structures.container.controller) creep.room.structures.container.controller.forEach(getSpots);
             if (creep.room.structures.links.controller) creep.room.structures.links.controller.forEach(getSpots);
+            return spots;
         };
         let spots = determineSpots();
         if( spots.length > 0 ){

--- a/creep.behaviour.upgrader.js
+++ b/creep.behaviour.upgrader.js
@@ -1,11 +1,21 @@
 let mod = {};
 module.exports = mod;
 mod.name = 'upgrader';
+let invalidCreep = c => ['miner', 'upgrader'].includes(c.data.creepType) && c.data.determinatedSpot &&
+    (c.data.ttl > c.data.spawningTime || c.data.ttl > c.data.predictedRenewal);
 mod.approach = function(creep){
     let targetPos = new RoomPosition(creep.data.determinatedSpot.x, creep.data.determinatedSpot.y, creep.pos.roomName);
     let range = creep.pos.getRangeTo(targetPos);
-    if( range > 0 )
+    if( range > 0 ) {
+        if (range === 1) {
+            const creeps = targetPos.lookFor(LOOK_CREEPS);
+            if (creeps.length && _.some(creeps, invalidCreep)) {
+                // forget spots that have been improperly selected/unable to move to
+                delete creep.data.determinatedSpot;
+            }
+        }
         creep.drive( targetPos, 0, 0, range );
+    }
     return range;
 };
 mod.run = function(creep) {
@@ -15,63 +25,45 @@ mod.run = function(creep) {
     }
     if( !creep.action ) Population.registerAction(creep, Creep.action.upgrading, creep.room.controller);
     if( !creep.data.determinatedSpot ) {
-        let args = {
-            spots: [{
-                pos: creep.room.controller.pos,
-                range: 3
-            }],
-            checkWalkable: true,
-            where: null,
-            roomName: creep.pos.roomName
-        }
-        let addSpot = s => args.spots.push({
-            pos: s.pos,
-            range: 1
-        });
-        if( creep.room.structures.container.controller ){
-            creep.room.structures.container.controller.forEach(addSpot);
-        }
-        if( creep.room.structures.links.controller ){
-            creep.room.structures.links.controller.forEach(addSpot);
-        }
-        // dont take already taken
-        let taken = [];
-        let findInvalid = entry => {
-            if( entry.roomName == args.roomName && ['miner', 'upgrader'].includes(entry.creepType) && entry.determinatedSpot && entry.ttl > entry.spawningTime)
-                taken.push(entry.determinatedSpot)
+        let determineSpots = (ignoreSources=false) => {
+            let getSpots = s => {
+                let args = {
+                    spots: [{
+                        pos: creep.room.controller.pos,
+                        range: 3
+                    },
+                    {
+                        pos: s.pos,
+                        range: 1
+                    }],
+                    checkWalkable: true,
+                    where: pos => !_.some(pos.lookFor(LOOK_CREEPS), invalidCreep) && (ignoreSources || pos.findInRange(creep.room.sources, 1).length === 0),
+                    roomName: creep.pos.roomName
+                };
+                spots = spots.concat(Room.fieldsInRange(args));
+            };
+            if (creep.room.structures.container.controller) creep.room.structures.container.controller.forEach(getSpots);
+            if (creep.room.structures.links.controller) creep.room.structures.links.controller.forEach(getSpots);
         };
-        _.forEach(Memory.population, findInvalid);
-        // dont take miner spots
-        let invalid = taken.slice(0);
-        let sourcesInRange = creep.room.controller.pos.findInRange(creep.room.sources, 4);
-        let addAdjacent = source => source.pos.adjacent.forEach(pos => invalid.push({x:pos.x,y:pos.y}))
-        sourcesInRange.forEach(addAdjacent);
-
-        args.where = pos => { return !_.some(invalid,{x:pos.x,y:pos.y}); };
-        let spots = Room.fieldsInRange(args);
-        if( spots.length == 0 ){ 
-            // no position found. allow pos near sources
-            args.where = pos => { return !_.some(taken,{x:pos.x,y:pos.y}); };
-            spots = Room.fieldsInRange(args);
-        }
-        if( spots.length == 0 ){ 
-            // no position found. allow any
-            delete args.where;
-            spots = Room.fieldsInRange(args);
-        }
+        let spots = determineSpots();
         if( spots.length > 0 ){
+            // allow spots near sources
+            spots = determineSpots(true);
+        }
+        if (spots.length > 0) {
+            // prefer off roads
             let spot = creep.pos.findClosestByPath(spots, {filter: pos => {
                 return !_.some(
                     creep.room.lookForAt(LOOK_STRUCTURES, pos),
                     {'structureType': STRUCTURE_ROAD }
                 );
-            }})
+            }});
             if( !spot ) spot = creep.pos.findClosestByPath(spots) || spots[0];
             if( spot ) {
                 creep.data.determinatedSpot = {
                     x: spot.x,
                     y: spot.y
-                }
+                };
                 let spawn = Game.spawns[creep.data.motherSpawn];
                 if( spawn ) {
                     let path = spot.findPathTo(spawn, {ignoreCreeps: true});
@@ -85,7 +77,7 @@ mod.run = function(creep) {
     if( creep.data.determinatedSpot ) {
         if(CHATTY) creep.say('upgrading', SAY_PUBLIC);
         let range = this.approach(creep);
-        if( range == 0 ){
+        if( creep.room.controller && creep.pos.getRangeTo(creep.room.controller) <= 3){
             let carryThreshold = (creep.data.body&&creep.data.body.work ? creep.data.body.work : (creep.carryCapacity/2));
             if( creep.carry.energy <= carryThreshold ){
                 let store = creep.room.structures.links.controller.find(l => l.energy > 0);


### PR DESCRIPTION
As well as forgetting previous bad spot selection and upgrading as soon as they are in range.  One possible change from old code is the potential range to a source, this checks to ideally choose a spot that is not adjacent to a source if possible.

We could add withdrawing from storage and storage to spot selection as well if we want to.