### PR TITLE
Fix build action when transiting through room

### DIFF
--- a/creep.action.building.js
+++ b/creep.action.building.js
@@ -4,7 +4,7 @@ action.maxPerTarget = 3;
 action.targetRange = 3;
 action.maxPerAction = 3;
 action.isValidAction = function(creep){
-    return ( creep.carry.energy > 0 && creep.room.constructionSites.length > 0 );
+    return ( creep.carry.energy > 0 );
 };
 action.isAddableAction = function(creep){
     return ( !creep.room.population || !creep.room.population.actionCount[this.name] || creep.room.population.actionCount[this.name] < this.maxPerAction);

--- a/room.js
+++ b/room.js
@@ -845,36 +845,40 @@ mod.extend = function(){
             return find.apply(this, arguments);
     };
 
+    Room.routeCallback = function(targetRoomName, checkOwner, preferHighway) {
+        return function(roomName) {
+            if( roomName !== targetRoomName && ROUTE_ROOM_COST[roomName]) {
+                return ROUTE_ROOM_COST[roomName];
+            }
+            let isHighway = false;
+            if( preferHighway ){
+                let parsed = /^[WE]([0-9]+)[NS]([0-9]+)$/.exec(roomName);
+                isHighway = (parsed[1] % 10 === 0) || (parsed[2] % 10 === 0);
+            }
+            let isMyOrNeutralRoom = false;
+            if( checkOwner ){
+                let room = Game.rooms[roomName];
+                isMyOrNeutralRoom = room &&
+                    room.controller &&
+                    (room.controller.my ||
+                    (room.controller.owner === undefined));
+            }
+
+            if (isMyOrNeutralRoom || roomName == targetRoomName)
+                return 1;
+            else if (isHighway)
+                return 3;
+            else if( Game.map.isRoomAvailable(roomName))
+                return (checkOwner || preferHighway) ? 11 : 1;
+            return Infinity;
+        };
+    };
+
     Room.prototype.findRoute = function(targetRoomName, checkOwner = true, preferHighway = true){
         if (this.name == targetRoomName)  return [];
 
         return Game.map.findRoute(this, targetRoomName, {
-            routeCallback(roomName) {
-                if( roomName !== targetRoomName && ROUTE_ROOM_COST[roomName]) {
-                    return ROUTE_ROOM_COST[roomName];
-                }
-                let isHighway = false;
-                if( preferHighway ){
-                    let parsed = /^[WE]([0-9]+)[NS]([0-9]+)$/.exec(roomName);
-                    isHighway = (parsed[1] % 10 === 0) || (parsed[2] % 10 === 0);
-                }
-                let isMyOrNeutralRoom = false;
-                if( checkOwner ){
-                    let room = Game.rooms[roomName];
-                    isMyOrNeutralRoom = room &&
-                        room.controller &&
-                        (room.controller.my ||
-                        (room.controller.owner === undefined));
-                }
-
-                if (isMyOrNeutralRoom || roomName == targetRoomName)
-                    return 1;
-                else if (isHighway)
-                    return 3;
-                else if( Game.map.isRoomAvailable(roomName))
-                    return (checkOwner || preferHighway) ? 11 : 1;
-                return Infinity;
-            }
+            routeCallback: Room.routeCallback(targetRoomName, checkOwner, preferHighway)
         });
     };
 

--- a/room.js
+++ b/room.js
@@ -845,40 +845,36 @@ mod.extend = function(){
             return find.apply(this, arguments);
     };
 
-    Room.routeCallback = function(targetRoomName, checkOwner, preferHighway) {
-        return function(roomName) {
-            if( roomName !== targetRoomName && ROUTE_ROOM_COST[roomName]) {
-                return ROUTE_ROOM_COST[roomName];
-            }
-            let isHighway = false;
-            if( preferHighway ){
-                let parsed = /^[WE]([0-9]+)[NS]([0-9]+)$/.exec(roomName);
-                isHighway = (parsed[1] % 10 === 0) || (parsed[2] % 10 === 0);
-            }
-            let isMyOrNeutralRoom = false;
-            if( checkOwner ){
-                let room = Game.rooms[roomName];
-                isMyOrNeutralRoom = room &&
-                    room.controller &&
-                    (room.controller.my ||
-                    (room.controller.owner === undefined));
-            }
-
-            if (isMyOrNeutralRoom || roomName == targetRoomName)
-                return 1;
-            else if (isHighway)
-                return 3;
-            else if( Game.map.isRoomAvailable(roomName))
-                return (checkOwner || preferHighway) ? 11 : 1;
-            return Infinity;
-        };
-    };
-
     Room.prototype.findRoute = function(targetRoomName, checkOwner = true, preferHighway = true){
         if (this.name == targetRoomName)  return [];
 
         return Game.map.findRoute(this, targetRoomName, {
-            routeCallback: Room.routeCallback(targetRoomName, checkOwner, preferHighway)
+            routeCallback(roomName) {
+                if( roomName !== targetRoomName && ROUTE_ROOM_COST[roomName]) {
+                    return ROUTE_ROOM_COST[roomName];
+                }
+                let isHighway = false;
+                if( preferHighway ){
+                    let parsed = /^[WE]([0-9]+)[NS]([0-9]+)$/.exec(roomName);
+                    isHighway = (parsed[1] % 10 === 0) || (parsed[2] % 10 === 0);
+                }
+                let isMyOrNeutralRoom = false;
+                if( checkOwner ){
+                    let room = Game.rooms[roomName];
+                    isMyOrNeutralRoom = room &&
+                        room.controller &&
+                        (room.controller.my ||
+                        (room.controller.owner === undefined));
+                }
+
+                if (isMyOrNeutralRoom || roomName == targetRoomName)
+                    return 1;
+                else if (isHighway)
+                    return 3;
+                else if( Game.map.isRoomAvailable(roomName))
+                    return (checkOwner || preferHighway) ? 11 : 1;
+                return Infinity;
+            }
         });
     };
 


### PR DESCRIPTION
If a creep selects a build site, but paths through an external room to get there it loses its action because that room does not have any construction sites. If we want to prevent the action from being added when there are no construction sites, perhaps the check for constructionSites should be in the isAddableAction instead?