### PR TITLE
Stop trying to harvest if source has no free spaces

### DIFF
--- a/creep.action.harvesting.js
+++ b/creep.action.harvesting.js
@@ -6,10 +6,12 @@ action.isValidAction = function(creep){
 };
 action.isValidTarget = function(target) {
     return (target !== null && target.energy !== null && target.energy > 0 &&
-        (target.targetOf === undefined || !_.some(target.targetOf, c =>
-            (c.creepType === 'miner' || c.creepType === 'remoteMiner')
-                && c.body.work >= 5
-                && (c.ticksToLive || CREEP_LIFE_TIME) >= (c.data && c.data.predictedRenewal || 0)
+        (target.targetOf === undefined || 
+            (target.targetOf.length < target.accessibleFields &&
+                !_.some(target.targetOf, c => (c.creepType === 'miner' || c.creepType === 'remoteMiner')
+                    && c.body.work >= 5
+                    && (c.ticksToLive || CREEP_LIFE_TIME) >= (c.data && c.data.predictedRenewal || 0)
+                )
             )
         ));
 };


### PR DESCRIPTION
Just add a check to validTarget to make sure the source still has enough spaces to harvest.  Prevents heavy CPU usage when trying to path to an unreachable source.