### PR TITLE
Feature/traveler unbuilt roads

### DIFF
--- a/parameter.js
+++ b/parameter.js
@@ -7,6 +7,7 @@ let mod = {
     DEBUG: true, // gimme some more details, use false not undefined to unset
     TRACE: false, // use Memory.debugTrace for low-level information
     TRAVELER_THRESHOLD: 50, // CPU Usage before warning about pathing cost
+    USE_UNBUILT_ROADS: true,
     GRAFANA: false, // track for Grafana data
     GRAFANA_INTERVAL: 3, // loops between Grafana tracking - No lower than 3.
     CENSUS_ANNOUNCEMENTS: true, // log birth and death

--- a/parameter.js
+++ b/parameter.js
@@ -7,7 +7,7 @@ let mod = {
     DEBUG: true, // gimme some more details, use false not undefined to unset
     TRACE: false, // use Memory.debugTrace for low-level information
     TRAVELER_THRESHOLD: 50, // CPU Usage before warning about pathing cost
-    USE_UNBUILT_ROADS: true,
+    USE_UNBUILT_ROADS: true, // enabling this will set the pathing cost of road construction sites to that of roads
     GRAFANA: false, // track for Grafana data
     GRAFANA_INTERVAL: 3, // loops between Grafana tracking - No lower than 3.
     CENSUS_ANNOUNCEMENTS: true, // log birth and death

--- a/traveler.js
+++ b/traveler.js
@@ -285,7 +285,10 @@ module.exports = function(globalOpts = {}){
                 }
             }
             for (let site of room.find(FIND_CONSTRUCTION_SITES)) {
-                if (site.structureType === STRUCTURE_CONTAINER || site.structureType === STRUCTURE_ROAD) {
+                if (site.structureType === STRUCTURE_CONTAINER) {
+                    continue;
+                } else if (site.structureType === STRUCTURE_ROAD) {
+                    if (USE_UNBUILT_ROADS) matrix.set(site.pos.x, site.pos.y, roadCost);
                     continue;
                 }
                 matrix.set(site.pos.x, site.pos.y, 0xff);


### PR DESCRIPTION
This feature when enabled will set road construction sites to the same pathing cost as fully built roads thus helping you to direct your creeps around pathing issues.

This works well with REMOTE_HAULER_DRIVE_BY_BUILDING as it makes sure the creeps actually follow the road you want built.