### PR TITLE
Hotfix/corrupt entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open Collaboration Society
 
-VERSION 0.6.1 - February 2017
+VERSION 0.6.2 - February 2017
 
 [![slack](https://img.shields.io/badge/chat-on%20slack-blue.svg)](https://screeps.slack.com/messages/ocs/)
 

--- a/spawn.js
+++ b/spawn.js
@@ -60,7 +60,7 @@ mod.extend = function(){
         }
         var completeName;
         var stumb = params.name;
-        for (var son = 1; completeName == null || Game.creeps[completeName]; son++) {
+        for (var son = 1; (completeName == null) || Game.creeps[completeName] || Memory.population[completeName]; son++) {
             completeName = params.name + '-' + son;
         }
         params.name = completeName;


### PR DESCRIPTION
MASTER fix, the effect of setting a name only based on the creep entry interferes with the process which tears down a creep's population entry

I've run overnight and this seems to have prevented my delivery flags from getting stuck at spawn.