### PR TITLE
room died creep is too big

### DIFF
--- a/task.pioneer.js
+++ b/task.pioneer.js
@@ -195,7 +195,6 @@ mod.creep = {
     },
     worker: {
         fixedBody: [MOVE, CARRY, WORK],
-        multiBody: [MOVE, CARRY, WORK], 
         behaviour: 'worker',
         queue: 'High'
     }


### PR DESCRIPTION
I had two rooms die from the handleRoomDied creep.

The simplest fix is to make that this backup creep is only a 200 energy creep.