### PR TITLE
storage charge property, returns percent of the "full" range

### DIFF
--- a/extensions.js
+++ b/extensions.js
@@ -177,6 +177,24 @@ mod.extend = function(){
             return this._sum;
         }
     });
+    Object.defineProperty(StructureStorage.prototype, 'charge', { // fraction indicating charge % relative to constants
+        configurable: true,
+        get: function() {
+            // TODO per-room strategy
+            const max = MAX_STORAGE_ENERGY[this.room.controller.level];
+            const min = MIN_STORAGE_ENERGY[this.room.controller.level];
+            if (max === min) {
+                if (this.store.energy > max) {
+                    return Infinity;
+                } else {
+                    return -Infinity;
+                }
+            }
+            const chargeScale = 1 / (max - min); // TODO cache
+
+            return (this.store.energy - max) * chargeScale + 1;
+        },
+    });
     Object.defineProperty(StructureTerminal.prototype, 'sum', {
         configurable: true,
         get: function() {


### PR DESCRIPTION
The full range represents when energy between min and max.

use cases:
* when you are over max energy storage: room.storage.charge > 1
* when you are under minimum energy storage: room.storage.charge < 0

Numerical computing - this is biased around 100% full, the difference between current and max is the most important comparison in many existing methods.

If the room minimum === maximum then the response is either `Infinity` or `-Infinity`.