### PR TITLE
Feature/critical cpu

### DIFF
--- a/creep.js
+++ b/creep.js
@@ -42,6 +42,9 @@ mod.extend = function(){
             if(!behaviour && this.data && this.data.creepType) {
                 behaviour = Creep.behaviour[this.data.creepType];
             }
+            if ( Game.cpu.bucket < CRITICAL_BUCKET_LEVEL && !CRITICAL_ROLES.includes(behaviour) ) {
+                return;
+            }
             this.repairNearby();
             if( DEBUG && TRACE ) trace('Creep', {creepName:this.name, pos:this.pos, Behaviour: behaviour && behaviour.name, Creep:'run'});
             if( behaviour ) behaviour.run(this);

--- a/creep.js
+++ b/creep.js
@@ -42,7 +42,7 @@ mod.extend = function(){
             if(!behaviour && this.data && this.data.creepType) {
                 behaviour = Creep.behaviour[this.data.creepType];
             }
-            if ( Game.cpu.bucket < CRITICAL_BUCKET_LEVEL && !CRITICAL_ROLES.includes(behaviour) ) {
+            if ( Game.cpu.bucket < CRITICAL_BUCKET_LEVEL && !CRITICAL_ROLES.includes(creep.data.creepType) ) {
                 return;
             }
             this.repairNearby();
@@ -447,6 +447,7 @@ mod.extend = function(){
     Creep.prototype.customStrategy = function(actionName, behaviourName, taskName) {};
 };
 mod.execute = function(){
+    if ( DEBUG && Game.cpu.bucket < CRITICAL_BUCKET_LEVEL ) logSystem('system',`${Game.time}: CPU Bucket level is critical (${Game.cpu.bucket}). Skipping non critical creep roles.`);
     let run = creep => creep.run();
     _.forEach(Game.creeps, run);
 };

--- a/creep.js
+++ b/creep.js
@@ -41,9 +41,9 @@ mod.extend = function(){
         if( !this.spawning ){
             if(!behaviour && this.data && this.data.creepType) {
                 behaviour = Creep.behaviour[this.data.creepType];
-            }
-            if ( Game.cpu.bucket < CRITICAL_BUCKET_LEVEL && !CRITICAL_ROLES.includes(creep.data.creepType) ) {
-                return;
+                if ( Game.cpu.bucket < CRITICAL_BUCKET_LEVEL && !CRITICAL_ROLES.includes(creep.data.creepType) ) {
+                    return;
+                }
             }
             this.repairNearby();
             if( DEBUG && TRACE ) trace('Creep', {creepName:this.name, pos:this.pos, Behaviour: behaviour && behaviour.name, Creep:'run'});

--- a/creep.js
+++ b/creep.js
@@ -41,7 +41,7 @@ mod.extend = function(){
         if( !this.spawning ){
             if(!behaviour && this.data && this.data.creepType) {
                 behaviour = Creep.behaviour[this.data.creepType];
-                if ( Game.cpu.bucket < CRITICAL_BUCKET_LEVEL && !CRITICAL_ROLES.includes(creep.data.creepType) ) {
+                if ( Game.cpu.bucket < CRITICAL_BUCKET_LEVEL && !CRITICAL_ROLES.includes(this.data.creepType) ) {
                     return;
                 }
             }

--- a/parameter.js
+++ b/parameter.js
@@ -130,6 +130,6 @@ let mod = {
     // Don't attack. Must be a member of OCS for permanent whitelisting in git repository. But you can change your own copy... Please ask if you are interested in joining OCS :)
     DEFENSE_BLACKLIST: [], // Don't defend those rooms (add room names). Blocks spawning via defense task (will not prevent offensive actions at all)
     CRITICAL_BUCKET_LEVEL: 1000, // take action when the bucket drops below this value to prevent the bucket from actually running out
-    CRITICAL_ROLES: [ 'melee', 'ranger', 'healer', 'upgrader' ], // when the bucket drops below the critical bucket level only these creep roles will be executed
+    CRITICAL_ROLES: [ 'melee', 'ranger', 'healer', 'hauler', 'upgrader' ], // when the bucket drops below the critical bucket level only these creep roles will be executed
 };
 module.exports = mod;

--- a/parameter.js
+++ b/parameter.js
@@ -130,6 +130,6 @@ let mod = {
     // Don't attack. Must be a member of OCS for permanent whitelisting in git repository. But you can change your own copy... Please ask if you are interested in joining OCS :)
     DEFENSE_BLACKLIST: [], // Don't defend those rooms (add room names). Blocks spawning via defense task (will not prevent offensive actions at all)
     CRITICAL_BUCKET_LEVEL: 1000, // take action when the bucket drops below this value to prevent the bucket from actually running out
-    CRITICAL_ROLES: [ 'melee', 'ranger', 'healer', 'hauler', 'upgrader' ], // when the bucket drops below the critical bucket level only these creep roles will be executed
+    CRITICAL_ROLES: [ 'melee', 'ranger', 'healer', 'miner', 'hauler', 'upgrader' ], // when the bucket drops below the critical bucket level only these creep roles will be executed
 };
 module.exports = mod;

--- a/parameter.js
+++ b/parameter.js
@@ -129,5 +129,7 @@ let mod = {
     PLAYER_WHITELIST: ['cyberblast','SirLovi','Asku','Kazume','Noxeth','MrDave','Telemac','Xephael','Zoiah','fsck-u','FaceWound','forkmantis','Migaaresno','xAix1999','silentpoots','arguinyano','OokieCookie','OverlordQ','Nibinhilion','Crowsbane','Yew','BogdanBiv','s1akr','Pandabear41','Logmadr','Patrik','novice','Conquest','ofirl','GeorgeBerkeley','TTR','tynstar','K-C','Hoekynl','Sunri5e','AgOrange','distantcam','Lisp','bbdMinimbl','Twill','Logxen','miR','Spedwards','Krazyfuq','Icesory','chobobobo','deft-code','mmmd','DKPlugins','pavelnieks','buckley310','almaravarion','SSH'],
     // Don't attack. Must be a member of OCS for permanent whitelisting in git repository. But you can change your own copy... Please ask if you are interested in joining OCS :)
     DEFENSE_BLACKLIST: [], // Don't defend those rooms (add room names). Blocks spawning via defense task (will not prevent offensive actions at all)
+    CRITICAL_BUCKET_LEVEL: 1000, // take action when the bucket drops below this value to prevent the bucket from actually running out
+    CRITICAL_ROLES: [ 'melee', 'ranger', 'healer', 'upgrader' ], // when the bucket drops below the critical bucket level only these creep roles will be executed
 };
 module.exports = mod;


### PR DESCRIPTION
This patch adds CRITICAL_BUCKET_LEVEL and CRITICAL_ROLE parameters. If the bucket goes below the CRITICAL_BUCKET_LEVEL the system will stop processing creeps except for those roles listed in CRITICAL_ROLES.

In this way the bucket can be held above the CRITICAL_BUCKET_LEVEL in most circumstances by allowing the user to effectively choose which creeps to skip and allows all non-creep room processes (such as towers) to continue running every tick. Contrast this behaviour with a bucket that is actually empty which causes random parts of the colony not to function.