### PR TITLE
call Population.registerAction more often

### DIFF
--- a/creep.Action.js
+++ b/creep.Action.js
@@ -89,7 +89,7 @@ let Action = function(actionName){
         if( target === undefined ) target = this.newTarget(creep);
         if( target != null ) {
             if( DEBUG && TRACE ) trace('Action', {creepName:creep.name, assign:this.name, target:!target || target.name || target.id, Action:'assign'});
-            if( creep.action == null || creep.action.name != this.name || creep.target == null || creep.target.id != target.id ) {
+            if( creep.action == null || creep.action.name != this.name || creep.target == null || creep.target.id != target.id || creep.target.name != target.name ) {
                 Population.registerAction(creep, this, target);
                 this.onAssignment(creep, target);
             }


### PR DESCRIPTION
 if assignment changes from one flag/spawn to another

feels like a possible bug waiting to bite us