### PR TITLE
creeps may not self target

### DIFF
--- a/creep.action.idle.js
+++ b/creep.action.idle.js
@@ -5,7 +5,7 @@ action.isValidAction = function(creep){ return true; };
 action.isAddableAction = function(creep){ return true; };
 action.isAddableTarget = function(target){ return true; };
 action.newTarget = function(creep){
-    return creep;
+    return FlagDir.specialFlag();
 };
 action.step = function(creep){
     if(CHATTY) creep.say(this.name, SAY_PUBLIC);

--- a/creep.action.travelling.js
+++ b/creep.action.travelling.js
@@ -9,7 +9,7 @@ action.step = function(creep){
     if( creep.target ){
         let pos;
         let targetRange = this.targetRange;
-        if( creep.target.id == creep.id ) {
+        if( FlagDir.isSpecialFlag(creep.target) ) {
             targetRange = 24;
             pos = new RoomPosition(25, 25, creep.data.travelRoom);
         }

--- a/creep.behaviour.privateer.js
+++ b/creep.behaviour.privateer.js
@@ -150,7 +150,7 @@ mod.exploitNextRoom = function(creep){
     Population.registerCreepFlag(creep, null);
     if (creep.room.name !== creep.data.homeRoom) {
         creep.data.travelRoom = creep.data.homeRoom;
-        Creep.action.travelling.assign(creep, creep);
+        Creep.action.travelling.assign(creep, FlagDir.specialFlag());
     }
     return false;
 };

--- a/flagDir.js
+++ b/flagDir.js
@@ -187,7 +187,6 @@ mod.specialFlag = function(create) {
     if (create) {
         if (!flag) {
             return _(Game.rooms).values().some(function (room) {
-                room.createFlag()
                 new RoomPosition(49, 49, room.name).createFlag(name, COLOR_WHITE, COLOR_PURPLE);
                 return true;
             });

--- a/flagDir.js
+++ b/flagDir.js
@@ -143,7 +143,6 @@ mod.flush = function(){
     delete this._hasInvasionFlag;
 };
 mod.analyze = function(){
-    const specialFlag = mod.specialFlag(true);
     let register = flag => {
         flag.creeps = {};
         if( flag.cloaking && flag.cloaking > 0 ) flag.cloaking--;
@@ -165,6 +164,7 @@ mod.analyze = function(){
         }
     }
     _.forEach(Memory.flags, findStaleFlags);
+    const specialFlag = mod.specialFlag(true);
     return !!specialFlag;
 };
 mod.execute = function() {
@@ -186,11 +186,13 @@ mod.specialFlag = function(create) {
     const flag = Game.flags[name];
     if (create) {
         if (!flag) {
-            _(Game.rooms).values().some(function (room) {
+            return _(Game.rooms).values().some(function (room) {
+                console.log('create flag');
                 new RoomPosition(49, 49, room.name).createFlag(name, COLOR_WHITE, COLOR_PURPLE);
                 return true;
             });
-        } else if (flag.roomName !== 'W0N0') {
+        } else if (flag.pos.roomName !== 'W0N0') {
+            console.log('move flag');
             flag.setPosition(new RoomPosition(49, 49, 'W0N0'));
         }
     }

--- a/flagDir.js
+++ b/flagDir.js
@@ -143,6 +143,7 @@ mod.flush = function(){
     delete this._hasInvasionFlag;
 };
 mod.analyze = function(){
+    mod.specialFlag(true);
     let register = flag => {
         flag.creeps = {};
         if( flag.cloaking && flag.cloaking > 0 ) flag.cloaking--;
@@ -178,4 +179,18 @@ mod.execute = function() {
 mod.cleanup = function(){
     let clearMemory = flagName => delete Memory.flags[flagName];
     this.stale.forEach(clearMemory);
+};
+mod.specialFlag = function(create) {
+    const name = '_OCS';
+    const flag = Game.flags[name];
+    if (create && !flag) {
+        _(Game.rooms).values().some(function(room) {
+            new RoomPosition(49, 49, room.name).createFlag(name, COLOR_WHITE, COLOR_PURPLE);
+            return true;
+        });
+    }
+    return flag;
+};
+mod.isSpecialFlag = function(object) {
+    return object.name === '_OCS';
 };

--- a/flagDir.js
+++ b/flagDir.js
@@ -184,11 +184,15 @@ mod.cleanup = function(){
 mod.specialFlag = function(create) {
     const name = '_OCS';
     const flag = Game.flags[name];
-    if (create && !flag) {
-        _(Game.rooms).values().some(function(room) {
-            new RoomPosition(49, 49, room.name).createFlag(name, COLOR_WHITE, COLOR_PURPLE);
-            return true;
-        });
+    if (create) {
+        if (!flag) {
+            _(Game.rooms).values().some(function (room) {
+                new RoomPosition(49, 49, room.name).createFlag(name, COLOR_WHITE, COLOR_PURPLE);
+                return true;
+            });
+        } else if (flag.roomName !== 'W0N0') {
+            flag.setPosition(new RoomPosition(49, 49, 'W0N0'));
+        }
     }
     return flag;
 };

--- a/flagDir.js
+++ b/flagDir.js
@@ -143,7 +143,7 @@ mod.flush = function(){
     delete this._hasInvasionFlag;
 };
 mod.analyze = function(){
-    mod.specialFlag(true);
+    const specialFlag = mod.specialFlag(true);
     let register = flag => {
         flag.creeps = {};
         if( flag.cloaking && flag.cloaking > 0 ) flag.cloaking--;
@@ -165,6 +165,7 @@ mod.analyze = function(){
         }
     }
     _.forEach(Memory.flags, findStaleFlags);
+    return !!specialFlag;
 };
 mod.execute = function() {
     let triggerFound = entry => {

--- a/flagDir.js
+++ b/flagDir.js
@@ -187,12 +187,11 @@ mod.specialFlag = function(create) {
     if (create) {
         if (!flag) {
             return _(Game.rooms).values().some(function (room) {
-                console.log('create flag');
+                room.createFlag()
                 new RoomPosition(49, 49, room.name).createFlag(name, COLOR_WHITE, COLOR_PURPLE);
                 return true;
             });
         } else if (flag.pos.roomName !== 'W0N0') {
-            console.log('move flag');
             flag.setPosition(new RoomPosition(49, 49, 'W0N0'));
         }
     }

--- a/main.js
+++ b/main.js
@@ -250,7 +250,9 @@ module.exports.loop = function () {
     if( global.mainInjection.flush ) global.mainInjection.flush();
 
     // analyze environment
-    FlagDir.analyze();
+    if (!FlagDir.analyze()) {
+        return;
+    }
     Room.analyze();
     Population.analyze();
     // custom analyze

--- a/main.js
+++ b/main.js
@@ -249,8 +249,9 @@ module.exports.loop = function () {
     // custom flush
     if( global.mainInjection.flush ) global.mainInjection.flush();
 
-    // analyze environment
+    // analyze environment, wait a tick if critical failure
     if (!FlagDir.analyze()) {
+        logError('FlagDir.analyze failed, waiting one tick to sync flags');
         return;
     }
     Room.analyze();

--- a/population.js
+++ b/population.js
@@ -31,6 +31,7 @@ mod.unregisterCreep = function(creepName){
 mod.registerAction = function(creep, action, target, entry) {
     if( DEBUG && TRACE ) trace('Population', {creepName:this.name, registerAction:action.name, target:target.name || target.id, Population:'registerAction'});
 
+    if( creep === target ) throw new Error('attempt to register self target');
     if( entry === undefined ) entry = this.getCreep(creep.name);
     entry.carryCapacityLeft = creep.carryCapacity - creep.sum;
     let room = creep.room;

--- a/population.js
+++ b/population.js
@@ -89,7 +89,7 @@ mod.registerAction = function(creep, action, target, entry) {
     }
     // register target
     entry.targetId = targetId;
-    if( target ) {
+    if( target && !FlagDir.isSpecialFlag(target)) {
         if( target.targetOf === undefined )
             target.targetOf = [entry];
         else target.targetOf.push(entry);

--- a/population.js
+++ b/population.js
@@ -210,6 +210,9 @@ mod.analyze = function(){
             }
             let action = ( entry.actionName && Creep.action[entry.actionName] ) ? Creep.action[entry.actionName] : null;
             let target = action && entry.targetId ? Game.getObjectById(entry.targetId) || Game.spawns[entry.targetId] || Game.flags[entry.targetId] : null;
+            if (target && target.id === creep.id) {
+                target = FlagDir.specialFlag();
+            }
             if( action && target ) this.registerAction( creep, action, target, entry );
             else {
                 delete entry.actionName;

--- a/task.defense.js
+++ b/task.defense.js
@@ -175,7 +175,7 @@ mod.nextAction = creep => {
     // travel to initial calling room
     let callingRoom = Game.rooms[creep.data.destiny.spottedIn];
     if( !callingRoom || callingRoom.hostiles.length > 0 ) {
-        Creep.action.travelling.assign(creep, creep);
+        Creep.action.travelling.assign(creep, FlagDir.specialFlag());
         creep.data.travelRoom = creep.data.destiny.spottedIn;
         return;
     }
@@ -183,7 +183,7 @@ mod.nextAction = creep => {
     let hasHostile = roomName => Game.rooms[roomName] && Game.rooms[roomName].hostiles.length > 0;
     let invasionRoom = creep.room.adjacentRooms.find(hasHostile);
     if( invasionRoom ) {
-        Creep.action.travelling.assign(creep, creep);
+        Creep.action.travelling.assign(creep, FlagDir.specialFlag());
         creep.data.travelRoom = invasionRoom;
         return;
     }


### PR DESCRIPTION
this attempts to fix the SK circular reference problem

my current hypothesis is that circular references are more likely to occur in SK rooms and this is possible outside that scenario (defenders or privateers traveling to rooms without vision)

the core mechanic is that all creeps use the "special flag" to denote the old self-targeting conditions (idle and travel)