### PR TITLE
Change target selection from ByPath to ByRange

### DIFF
--- a/creep.action.feeding.js
+++ b/creep.action.feeding.js
@@ -16,7 +16,7 @@ action.isAddableTarget = function(target){
 };
 action.newTarget = function(creep){
     var that = this;
-    return creep.pos.findClosestByPath(creep.room.structures.all, {
+    return creep.pos.findClosestByRange(creep.room.structures.all, {
         filter: (structure) => {
             return ((structure.structureType == STRUCTURE_EXTENSION ||
                 structure.structureType == STRUCTURE_SPAWN )


### PR DESCRIPTION
This comes with the possibility that there will be some unforseen base layout that causes creeps to select a target that is unreasonably far away.  If you have one of these issues, please report it with details.