### PR TITLE
RemoteHaulers use storage in more cases

### DIFF
--- a/creep.behaviour.remoteHauler.js
+++ b/creep.behaviour.remoteHauler.js
@@ -30,8 +30,9 @@ mod.nextAction = function(creep){
             // Choose the closest
             if( deposit.length > 0 ){
                 let target = creep.pos.findClosestByRange(deposit);
-                if( target.structureType == STRUCTURE_STORAGE && this.assign(creep, Creep.action.storing) ) return;
+                if( target.structureType == STRUCTURE_STORAGE && this.assign(creep, Creep.action.storing, target) ) return;
                 else if( this.assign(creep, Creep.action.charging, target) ) return;
+                else if( this.assign(creep, Creep.action.storing) ) return; // prefer storage
             }
             if( this.assign(creep, Creep.action.charging) ) return;
             // no deposit :/ 


### PR DESCRIPTION
Previously when remoteHaulers found a potentially chargable target closer than storage, they would potentially ignore the storage.