### PR TITLE
remote hauler min weight is more aggressive for the 2nd+ haulers

### DIFF
--- a/parameter.js
+++ b/parameter.js
@@ -124,6 +124,7 @@ let mod = {
     REMOTE_HAULER_REHOME: false, // May haulers choose closer storage for delivery?
     REMOTE_HAULER_MIN_LOAD: 0.75, // Haulers will return home as long as their ratio of carrying/capacity is above this amount.
     REMOTE_HAULER_MIN_WEIGHT: 800, // Small haulers are a CPU drain.
+    REMOTE_HAULER_ALLOW_OVER_CAPACITY: false, // Allows remote hauler capacity to round up.
     REMOTE_HAULER_DRIVE_BY_BUILDING: false, // Allows remote haulers to build roads and containers. Consider setting REMOTE_WORKER_MULTIPLIER to 0.
     REMOTE_HAULER_DRIVE_BY_BUILD_RANGE: 1, // A creep's max build distance is 3 but cpu can be saved by dropping the search distance to 1.
     REMOTE_HAULER_DRIVE_BY_BUILD_ALL: false, // If REMOTE_HAULER_DRIVE_BY_BUILDING is enabled then this option will allow remote haulers will drive-by-build any of your structures.

--- a/parameter.js
+++ b/parameter.js
@@ -124,7 +124,7 @@ let mod = {
     REMOTE_HAULER_REHOME: false, // May haulers choose closer storage for delivery?
     REMOTE_HAULER_MIN_LOAD: 0.75, // Haulers will return home as long as their ratio of carrying/capacity is above this amount.
     REMOTE_HAULER_MIN_WEIGHT: 800, // Small haulers are a CPU drain.
-    REMOTE_HAULER_ALLOW_OVER_CAPACITY: false, // Allows remote hauler capacity to round up.
+    REMOTE_HAULER_ALLOW_OVER_CAPACITY: false, // Hauler capacity rounds up by MIN_WEIGHT, or this number value.
     REMOTE_HAULER_DRIVE_BY_BUILDING: false, // Allows remote haulers to build roads and containers. Consider setting REMOTE_WORKER_MULTIPLIER to 0.
     REMOTE_HAULER_DRIVE_BY_BUILD_RANGE: 1, // A creep's max build distance is 3 but cpu can be saved by dropping the search distance to 1.
     REMOTE_HAULER_DRIVE_BY_BUILD_ALL: false, // If REMOTE_HAULER_DRIVE_BY_BUILDING is enabled then this option will allow remote haulers will drive-by-build any of your structures.

--- a/task.mining.js
+++ b/task.mining.js
@@ -215,13 +215,16 @@ mod.checkForRequiredCreeps = (flag) => {
     const maxHaulers = Math.ceil(memory.running.remoteMiner.length * REMOTE_HAULER_MULTIPLIER);
     if(haulerCount < maxHaulers && (!memory.capacityLastChecked || Game.time - memory.capacityLastChecked > REMOTE_HAULER_CHECK_INTERVAL)) {
         for(let i = haulerCount; i < maxHaulers; i++) {
-            const spawnRoom = mod.strategies.hauler.spawnRoom(roomName);
-            if( !spawnRoom ) break;
+            const minWeight = i >= 1 && REMOTE_HAULER_MIN_WEIGHT;
+            const spawnRoom = mod.strategies.hauler.spawnRoom({roomName, minWeight});
+            if( !spawnRoom ) {
+                break;
+            }
 
             // haulers set homeRoom if closer storage exists
             const storageRoom = REMOTE_HAULER_REHOME && mod.strategies.hauler.homeRoom(roomName) || spawnRoom;
             const maxWeight = mod.strategies.hauler.maxWeight(roomName, storageRoom, memory); // TODO Task.strategies
-            if( !maxWeight || (i >= 1 && maxWeight < REMOTE_HAULER_MIN_WEIGHT)) {
+            if( !maxWeight || (!REMOTE_HAULER_ALLOW_OVER_CAPACITY && maxWeight < minWeight)) {
                 memory.capacityLastChecked = Game.time;
                 break;
             }
@@ -229,6 +232,7 @@ mod.checkForRequiredCreeps = (flag) => {
             // spawning a new hauler
             const creepDefinition = _.create(Task.mining.creep.hauler);
             creepDefinition.maxWeight = maxWeight;
+            if (minWeight) creepDefinition.minWeight = minWeight;
             Task.spawn(
                 creepDefinition,
                 { // destiny
@@ -484,10 +488,10 @@ mod.strategies = {
             // Otherwise, score it
             return Room.bestSpawnRoomFor(flagRoomName);
         },
-        spawnRoom: function(flagRoomName) {
+        spawnRoom: function({roomName, minWeight}) {
             return Room.findSpawnRoom({
-                targetRoom: flagRoomName,
-                minEnergyCapacity: 500
+                targetRoom: roomName,
+                minEnergyCapacity: minWeight || 500,
             });
         },
         maxWeight: function(roomName, travelRoom, memory, ignorePopulation, ignoreQueue) {

--- a/task.mining.js
+++ b/task.mining.js
@@ -215,7 +215,7 @@ mod.checkForRequiredCreeps = (flag) => {
     const maxHaulers = Math.ceil(memory.running.remoteMiner.length * REMOTE_HAULER_MULTIPLIER);
     if(haulerCount < maxHaulers && (!memory.capacityLastChecked || Game.time - memory.capacityLastChecked > REMOTE_HAULER_CHECK_INTERVAL)) {
         for(let i = haulerCount; i < maxHaulers; i++) {
-            const minWeight = i >= 1 && REMOTE_HAULER_MIN_WEIGHT;
+            let minWeight = i >= 1 && REMOTE_HAULER_MIN_WEIGHT;
             const spawnRoom = mod.strategies.hauler.spawnRoom({roomName, minWeight});
             if( !spawnRoom ) {
                 break;
@@ -231,8 +231,10 @@ mod.checkForRequiredCreeps = (flag) => {
 
             if (_.isNumber(REMOTE_HAULER_ALLOW_OVER_CAPACITY)) {
                 maxWeight = Math.max(maxWeight, REMOTE_HAULER_ALLOW_OVER_CAPACITY);
+                minWeight = minWeight && Math.min(REMOTE_HAULER_MIN_WEIGHT, maxWeight);
             } else if (REMOTE_HAULER_ALLOW_OVER_CAPACITY) {
                 maxWeight = Math.max(maxWeight, REMOTE_HAULER_MIN_WEIGHT);
+                minWeight = minWeight && Math.min(REMOTE_HAULER_MIN_WEIGHT, maxWeight);
             }
 
             // spawning a new hauler

--- a/task.mining.js
+++ b/task.mining.js
@@ -223,10 +223,16 @@ mod.checkForRequiredCreeps = (flag) => {
 
             // haulers set homeRoom if closer storage exists
             const storageRoom = REMOTE_HAULER_REHOME && mod.strategies.hauler.homeRoom(roomName) || spawnRoom;
-            const maxWeight = mod.strategies.hauler.maxWeight(roomName, storageRoom, memory); // TODO Task.strategies
+            let maxWeight = mod.strategies.hauler.maxWeight(roomName, storageRoom, memory); // TODO Task.strategies
             if( !maxWeight || (!REMOTE_HAULER_ALLOW_OVER_CAPACITY && maxWeight < minWeight)) {
                 memory.capacityLastChecked = Game.time;
                 break;
+            }
+
+            if (_.isNumber(REMOTE_HAULER_ALLOW_OVER_CAPACITY)) {
+                maxWeight = Math.max(maxWeight, REMOTE_HAULER_ALLOW_OVER_CAPACITY);
+            } else if (REMOTE_HAULER_ALLOW_OVER_CAPACITY) {
+                maxWeight = Math.max(maxWeight, REMOTE_HAULER_MIN_WEIGHT);
             }
 
             // spawning a new hauler


### PR DESCRIPTION
REMOTE_HAULER_ALLOW_OVER_CAPACITY allows "rounding up" the total capacity

this is VERY shocking to the cpu... you may wish to check out the histogram of your haulers:

`JSON.stringify(_.chain(Game.creeps).filter(i=>i.data.creepType==='remoteHauler').groupBy('data.weight').mapValues(i=>i.length))`

and then recycle the small ones

`_.chain(Game.creeps).filter(i=>i.data.creepType==='remoteHauler').filter(i=>i.data.weight < 1400).map(i=>i.data.creepType='recycler')`