### PR TITLE
fast enumeration of all exits

### DIFF
--- a/room.js
+++ b/room.js
@@ -1912,7 +1912,8 @@ mod.extend = function(){
         //console.log(lab_master,"found slave labs",lab_slave_a,"for",component_a,"and",lab_slave_b,"for",component_b);
         return OK;
     };
-    Room.prototype.exits = function(findExit) {
+    Room.prototype.exits = function(findExit, point) {
+        if (point === true) point = 0.5;
         let positions;
         if (findExit === 0) {
             // portals
@@ -1924,17 +1925,30 @@ mod.extend = function(){
         }
 
         // assuming in-order
+        let maxX, maxY;
         let map = {};
-        let limit = 0;
+        let limit = -1;
         const ret = [];
         for (let i = 0; i < positions.length; i++) {
             const pos = positions[i];
             if (!(_.get(map,[pos.x-1, pos.y]) || _.get(map,[pos.x,pos.y-1]))) {
-                ret[limit] = _.pick(pos, ['x','y']);
-                map = {};
+                if (point && limit !== -1) {
+                    ret[limit].x += Math.ceil(point * (maxX - ret[limit].x));
+                    ret[limit].y += Math.ceil(point * (maxY - ret[limit].y));
+                }
                 limit++;
-            }
+                ret[limit] = _.pick(pos, ['x','y']);
+                maxX = pos.x;
+                maxY = pos.y;
+                map = {};
+            }``
             _.set(map, [pos.x, pos.y], true);
+            maxX = Math.max(maxX, pos.x);
+            maxY = Math.max(maxY, pos.y);
+        }
+        if (point && limit !== -1) {
+            ret[limit].x += Math.ceil(point * (maxX - ret[limit].x));
+            ret[limit].y += Math.ceil(point * (maxY - ret[limit].y));
         }
         return ret;
     }

--- a/room.js
+++ b/room.js
@@ -1912,6 +1912,32 @@ mod.extend = function(){
         //console.log(lab_master,"found slave labs",lab_slave_a,"for",component_a,"and",lab_slave_b,"for",component_b);
         return OK;
     };
+    Room.prototype.exits = function(findExit) {
+        let positions;
+        if (findExit === 0) {
+            // portals
+            positions = _.chain(this.find(FIND_STRUCTURES)).filter(function(s) {
+                return s.structureType === STRUCTURE_PORTAL;
+            }).map('pos').value();
+        } else {
+            positions = this.find(findExit);
+        }
+
+        // assuming in-order
+        let map = {};
+        let limit = 0;
+        const ret = [];
+        for (let i = 0; i < positions.length; i++) {
+            const pos = positions[i];
+            if (!(_.get(map,[pos.x-1, pos.y]) || _.get(map,[pos.x,pos.y-1]))) {
+                ret[limit] = _.pick(pos, ['x','y']);
+                map = {};
+                limit++;
+            }
+            _.set(map, [pos.x, pos.y], true);
+        }
+        return ret;
+    }
 };
 mod.flush = function(){
     let clean = room => {

--- a/room.js
+++ b/room.js
@@ -1941,7 +1941,7 @@ mod.extend = function(){
                 maxX = pos.x;
                 maxY = pos.y;
                 map = {};
-            }``
+            }
             _.set(map, [pos.x, pos.y], true);
             maxX = Math.max(maxX, pos.x);
             maxY = Math.max(maxY, pos.y);


### PR DESCRIPTION
Asking for Room.prototype.exits(number) will list room positions that represent each contiguous exit.

Usage:

Find one position representing all the separate portal structures in a room.
> `Game.rooms.E75S5.exits(0)`
< `[{"x":36,"y":19}]`

Find the single large top exit
> `Game.rooms.E75S5.exits(FIND_EXIT_TOP))`
< `[{"x":5,"y":0}]`

Find the single small right exit
> `Game.rooms.E75S5.exits(FIND_EXIT_RIGHT))`
< `[{"x":49,"y":35}]`

Find the three small bottom exits
> `JSON.stringify(Game.rooms.E75S5.exits(FIND_EXIT_BOTTOM))`
< `[{"x":7,"y":49},{"x":20,"y":49},{"x":32,"y":49}]`

Find the two small left exits
> `Game.rooms.E75S5.exits(FIND_EXIT_LEFT)`
 < `[{"x":0,"y":3},{"x":0,"y":24}]`

Find all the regular exits
> `Game.rooms.E75S5.exits(FIND_EXIT)`
< `[{"x":5,"y":0},{"x":7,"y":49},{"x":20,"y":49},{"x":32,"y":49},{"x":49,"y":35},{"x":0,"y":3},{"x":0,"y":24}]`

This isn't cached and `FIND_EXIT` doesn't return portals. I think both of those are worthwhile additions.