### PR TITLE
Feature/traveler caching

### DIFF
--- a/main.js
+++ b/main.js
@@ -219,7 +219,7 @@ global.install = () => {
     if( global.mainInjection.extend ) global.mainInjection.extend();
 };
 global.install();
-require('traveler')({exportTraveler: false, installTraveler: false, installPrototype: true, defaultStuckValue: TRAVELER_STUCK_TICKS, reportThreshold: TRAVELER_THRESHOLD});
+require('traveler')({exportTraveler: false, installTraveler: true, installPrototype: true, defaultStuckValue: TRAVELER_STUCK_TICKS, reportThreshold: TRAVELER_THRESHOLD});
 
 let cpuAtFirstLoop;
 module.exports.loop = function () {

--- a/room.js
+++ b/room.js
@@ -987,6 +987,24 @@ mod.extend = function(){
         });
     };
 
+    Room.prototype.getPath = (start, finish, options) => {
+        let path = this.memory.paths[creep.pos.x + ',' + creep.pos.y][destID];
+        if (!path) {
+            if(global.traveler && global.travelerTick !== Game.time){
+                global.traveler = new Traveler();
+            }
+            const ret = traveler.findTravelPath(start, finish, options);
+            if (!ret || ret.incomplete) {
+                logError('Room.getPath incomplete path from' + start + finish);
+                return;
+            } else {
+                path = Traveler.serializePath(start, ret.path);
+            }
+            this.memory.paths[creep.pos.x + ',' + creep.pos.y][destID] = path;
+        }
+        return path;
+    };
+
     Room.prototype.getBestConstructionSiteFor = function(pos, filter = null) {
         let sites;
         if( filter ) sites = this.constructionSites.filter(filter);

--- a/traveler.js
+++ b/traveler.js
@@ -358,19 +358,22 @@ module.exports = function(globalOpts = {}){
 
         Creep.prototype.travelTo = function (destination, options = {}) {
             options = this.getStrategyHandler([], 'moveOptions', options);
+            if (_.isUndefined(options.cacheRoutes)) options.cacheRoutes = true;
             if (_.isUndefined(options.allowHostile)) options.allowHostile = false;
             if (_.isUndefined(options.routeCallback)) options.routeCallback = Room.routeCallback(destination.roomName, options.allowHostile, options.preferHighway);
             if (_.isUndefined(options.useFindRoute)) options.useFindRoute = global.ROUTE_PRECALCULATION;
             if (options.cacheRoutes) {
-                const destID = destination.id || dest.x + ',' + dest.y;
-                const path = creep.room.getPath(creep.pos, destination);
+                const path = this.room.getPath(this.pos, destination);
                 if (path){
-                    const next = path[creep.pos.x + ',' + creep.pos.y];
-                    if (next) return creep.move(next); // take next step
+                    const next = path[this.pos.x + ',' + this.pos.y];
+                    if (next) {
+                        //console.log(this.name, this.pos, 'cached', next);
+                        return this.move(next); // take next step
+                    }
                     else { // TODO:find closest place to get on the path
-                        console.log('could not generate or use cached route, falling back to traveler.');
+                        console.log(this.name, 'could not generate or use cached route, falling back to traveler.');
                         options.cacheRoutes = false;
-                        return creep.travelTo(dest, options);
+                        return this.travelTo(destination, options);
                     }
                 }
             } else {

--- a/traveler.js
+++ b/traveler.js
@@ -357,14 +357,28 @@ module.exports = function(globalOpts = {}){
         }
 
         Creep.prototype.travelTo = function (destination, options = {}) {
-            if(global.traveler && global.travelerTick !== Game.time){
-                global.traveler = new Traveler();
-            }
             options = this.getStrategyHandler([], 'moveOptions', options);
             if (_.isUndefined(options.allowHostile)) options.allowHostile = false;
             if (_.isUndefined(options.routeCallback)) options.routeCallback = Room.routeCallback(destination.roomName, options.allowHostile, options.preferHighway);
             if (_.isUndefined(options.useFindRoute)) options.useFindRoute = global.ROUTE_PRECALCULATION;
-            return traveler.travelTo(this, destination, options);
+            if (options.routeCache) {
+                const destID = destination.id || dest.x + ',' + dest.y;
+                const path = creep.room.getPath(creep.pos, destination);
+                if (path){
+                    const next = path[creep.pos.x + ',' + creep.pos.y];
+                    if (next) return creep.move(next); // take next step
+                    else { // TODO:find closest place to get on the path
+                        console.log('could not generate or use cached route, falling back to traveler.');
+                        options.routeCache = false;
+                        return creep.travelTo(dest, options);
+                    }
+                }
+            } else {
+                if(global.traveler && global.travelerTick !== Game.time){
+                    global.traveler = new Traveler();
+                }
+                return traveler.travelTo(this, destination, options);                
+            }
         };
     }
 

--- a/traveler.js
+++ b/traveler.js
@@ -361,7 +361,7 @@ module.exports = function(globalOpts = {}){
             if (_.isUndefined(options.allowHostile)) options.allowHostile = false;
             if (_.isUndefined(options.routeCallback)) options.routeCallback = Room.routeCallback(destination.roomName, options.allowHostile, options.preferHighway);
             if (_.isUndefined(options.useFindRoute)) options.useFindRoute = global.ROUTE_PRECALCULATION;
-            if (options.routeCache) {
+            if (options.cacheRoutes) {
                 const destID = destination.id || dest.x + ',' + dest.y;
                 const path = creep.room.getPath(creep.pos, destination);
                 if (path){
@@ -369,7 +369,7 @@ module.exports = function(globalOpts = {}){
                     if (next) return creep.move(next); // take next step
                     else { // TODO:find closest place to get on the path
                         console.log('could not generate or use cached route, falling back to traveler.');
-                        options.routeCache = false;
+                        options.cacheRoutes = false;
                         return creep.travelTo(dest, options);
                     }
                 }


### PR DESCRIPTION
A work in progress branch to cache all routes that use travelBy and reuse them. Currently if there is not a saved route from the creep's position one is generated, if the generated route crosses an existing route to that destination they merge.

There is a good chance there are CPU issues with this form of pathfinding not respecting ranges, any creep that tracks a live/moving target will likely fail as well (caching should be turned off for them).  Moving a flag will likely break as well.

The memory usage might be a bit obscene as well.

This will likely conflict with assignRoom, and perhaps will eventually replace the need for it.