### PR TITLE
creep.Setup property dereferencing is more consistent

### DIFF
--- a/creep.Setup.js
+++ b/creep.Setup.js
@@ -26,20 +26,21 @@ let Setup = function(typeName){
     this.sortedParts = true;
     this.mixMoveParts = false;
 
+    this.rclProperty = Setup.rclProperty;
     this.SelfOrCall = function(obj, param) {
         if( obj == null ) return null;
         if (typeof obj === 'function' )
             return obj(param);
         else return obj;
     };
-    this.fixedBody = Setup.rclProperty(this, 'fixedBody');
-    this.multiBody = Setup.rclProperty(this, 'multiBody');
-    this.minAbsEnergyAvailable = Setup.rclProperty(this, 'minAbsEnergyAvailable');
-    this.minEnergyAvailable = Setup.rclProperty(this, 'minEnergyAvailable'); // 1 = full
-    this.minMulti = Setup.rclProperty(this, 'minMulti');
-    this.maxMulti = Setup.rclProperty(this, 'maxMulti');
-    this.maxCount = Setup.rclProperty(this, 'maxCount');
-    this.maxWeight = Setup.rclProperty(this, 'maxWeight');
+    this.fixedBody = this.rclProperty('fixedBody');
+    this.multiBody = this.rclProperty('multiBody');
+    this.minAbsEnergyAvailable = this.rclProperty('minAbsEnergyAvailable');
+    this.minEnergyAvailable = this.rclProperty('minEnergyAvailable'); // 1 = full
+    this.minMulti = this.rclProperty('minMulti');
+    this.maxMulti = this.rclProperty('maxMulti');
+    this.maxCount = this.rclProperty('maxCount');
+    this.maxWeight = this.rclProperty('maxWeight');
 
     this.buildParams = function(spawn){
         var memory = {
@@ -214,23 +215,24 @@ Setup.maxPerFlag = function(flagFilter, maxRoomRange, measureByHome) {
         return max;
     };
 };
-Setup.rclProperty = function(creepSetup, property) {
-    let rcl;
-    if (typeof creepSetup.RCL === 'function') {
-        rcl = function(room) {
-            return creepSetup.RCL(room.controller.level);
-        };
-    } else {
-        rcl = function(room) {
-            return creepSetup.RCL[room.controller.level];
-        };
-    }
-
-    if (property === undefined) {
-        return rcl;
-    }
-
+Setup.rclProperty = function(property) {
     return function(room) {
+        const creepSetup = this;
+        let rcl;
+        if (typeof creepSetup.RCL === 'function') {
+            rcl = function(room) {
+                return creepSetup.RCL(room.controller.level);
+            };
+        } else {
+            rcl = function(room) {
+                return creepSetup.RCL[room.controller.level];
+            };
+        }
+
+        if (property === undefined) {
+            return rcl;
+        }
+
         return creepSetup.SelfOrCall(rcl(room)[property], room);
     }
 };

--- a/creep.Setup.js
+++ b/creep.Setup.js
@@ -30,7 +30,7 @@ let Setup = function(typeName){
     this.SelfOrCall = function(obj, param) {
         if( obj == null ) return null;
         if (typeof obj === 'function' )
-            return obj(param);
+            return obj.apply(this, [param]);
         else return obj;
     };
     this.fixedBody = this.rclProperty('fixedBody');

--- a/creep.Setup.js
+++ b/creep.Setup.js
@@ -28,7 +28,7 @@ let Setup = function(typeName){
 
     this.rclProperty = Setup.rclProperty;
     this.SelfOrCall = function(obj, param) {
-        if( obj === null ) return null;
+        if( obj == null ) return null;
         if (typeof obj === 'function' )
             return obj.apply(this, [param]);
         else return obj;
@@ -57,7 +57,7 @@ let Setup = function(typeName){
         memory.cost = Creep.bodyCosts(memory.parts);
         memory.mother = spawn.name;
         memory.home = spawn.pos.roomName;
-        for( var son = 1; memory.name === null || Game.creeps[memory.name]; son++ ) {
+        for( var son = 1; memory.name == null || Game.creeps[memory.name]; son++ ) {
             memory.name = this.type + '-' + memory.cost + '-' + son;
         }
         return memory;
@@ -84,9 +84,9 @@ let Setup = function(typeName){
             if (DEBUG && TRACE) trace('Setup', {setupType:this.type, room:room.name, maxCount, maxWeight, Setup:'isValidSetup'}, 'too many creeps');
             return false;
         }
-        if( maxCount === null )
+        if( maxCount == null )
             maxCount = Infinity;
-        if( maxWeight === null )
+        if( maxWeight == null )
             maxWeight = Infinity;
 
         let existingCount = 0;

--- a/creep.Setup.js
+++ b/creep.Setup.js
@@ -7,7 +7,7 @@ let Setup = function(typeName){
         maxMulti: 0,
         maxCount: 0,
         maxWeight: 0
-    },
+    };
     this.RCL = {
         1: this.none,
         2: this.none,
@@ -17,7 +17,7 @@ let Setup = function(typeName){
         6: this.none,
         7: this.none,
         8: this.none
-    }
+    };
 
     this.type = typeName;
     this.minControllerLevel = 0;
@@ -28,19 +28,19 @@ let Setup = function(typeName){
 
     this.rclProperty = Setup.rclProperty;
     this.SelfOrCall = function(obj, param) {
-        if( obj == null ) return null;
+        if( obj === null ) return null;
         if (typeof obj === 'function' )
             return obj.apply(this, [param]);
         else return obj;
     };
-    this.fixedBody = this.rclProperty('fixedBody');
-    this.multiBody = this.rclProperty('multiBody');
-    this.minAbsEnergyAvailable = this.rclProperty('minAbsEnergyAvailable');
-    this.minEnergyAvailable = this.rclProperty('minEnergyAvailable'); // 1 = full
-    this.minMulti = this.rclProperty('minMulti');
-    this.maxMulti = this.rclProperty('maxMulti');
-    this.maxCount = this.rclProperty('maxCount');
-    this.maxWeight = this.rclProperty('maxWeight');
+    this._fixedBody = this.rclProperty('fixedBody');
+    this._multiBody = this.rclProperty('multiBody');
+    this._minAbsEnergyAvailable = this.rclProperty('minAbsEnergyAvailable');
+    this._minEnergyAvailable = this.rclProperty('minEnergyAvailable'); // 1 = full
+    this._minMulti = this.rclProperty('minMulti');
+    this._maxMulti = this.rclProperty('maxMulti');
+    this._maxCount = this.rclProperty('maxCount');
+    this._maxWeight = this.rclProperty('maxWeight');
 
     this.buildParams = function(spawn){
         var memory = {
@@ -57,7 +57,7 @@ let Setup = function(typeName){
         memory.cost = Creep.bodyCosts(memory.parts);
         memory.mother = spawn.name;
         memory.home = spawn.pos.roomName;
-        for( var son = 1; memory.name == null || Game.creeps[memory.name]; son++ ) {
+        for( var son = 1; memory.name === null || Game.creeps[memory.name]; son++ ) {
             memory.name = this.type + '-' + memory.cost + '-' + son;
         }
         return memory;
@@ -68,8 +68,8 @@ let Setup = function(typeName){
             return false;
         }
 
-        let minAbsEnergyAvailable = this.SelfOrCall(this.minAbsEnergyAvailable, room);
-        let minEnergyAvailable = this.SelfOrCall(this.minEnergyAvailable, room);
+        let minAbsEnergyAvailable = this.SelfOrCall(this._minAbsEnergyAvailable, room);
+        let minEnergyAvailable = this.SelfOrCall(this._minEnergyAvailable, room);
         const absEnergy = room.remainingEnergyAvailable;
         const energy = room.relativeRemainingEnergyAvailable;
         if( absEnergy < minAbsEnergyAvailable ||
@@ -78,15 +78,15 @@ let Setup = function(typeName){
             return false;
         }
 
-        let maxCount = this.SelfOrCall(this.maxCount, room);
-        let maxWeight = this.SelfOrCall(this.maxWeight, room);
-        if( maxCount == 0 || maxWeight == 0 ) {
+        let maxCount = this.SelfOrCall(this._maxCount, room);
+        let maxWeight = this.SelfOrCall(this._maxWeight, room);
+        if( maxCount === 0 || maxWeight === 0 ) {
             if (DEBUG && TRACE) trace('Setup', {setupType:this.type, room:room.name, maxCount, maxWeight, Setup:'isValidSetup'}, 'too many creeps');
             return false;
         }
-        if( maxCount == null )
+        if( maxCount === null )
             maxCount = Infinity;
-        if( maxWeight == null )
+        if( maxWeight === null )
             maxWeight = Infinity;
 
         let existingCount = 0;
@@ -128,12 +128,12 @@ let Setup = function(typeName){
         return existingWeight;
     };
     this.parts = function(room){
-        let fixedBody = this.SelfOrCall(this.fixedBody, room);
-        let multiBody = this.SelfOrCall(this.multiBody, room);
+        let fixedBody = this.SelfOrCall(this._fixedBody, room);
+        let multiBody = this.SelfOrCall(this._multiBody, room);
         var parts = [];
-        let min = this.SelfOrCall(this.minMulti, room);
-        let maxMulti = this.SelfOrCall(this.maxMulti, room);
-        let maxWeight = this.SelfOrCall(this.maxWeight, room);
+        let min = this.SelfOrCall(this._minMulti, room);
+        let maxMulti = this.SelfOrCall(this._maxMulti, room);
+        let maxWeight = this.SelfOrCall(this._maxWeight, room);
         let maxMultiWeight;
         if( maxWeight ){
             let existingWeight = this.existingWeight(room);
@@ -183,7 +183,7 @@ let Setup = function(typeName){
     };
     this.maxCost = function(room){
         let c = this;
-        return (Creep.bodyCosts( c.SelfOrCall(this.multiBody, room) ) * c.SelfOrCall(this.maxMulti, room)) + (Creep.bodyCosts(c.SelfOrCall(this.fixedBody, room)));
+        return (Creep.bodyCosts( c.SelfOrCall(this._multiBody, room) ) * c.SelfOrCall(this._maxMulti, room)) + (Creep.bodyCosts(c.SelfOrCall(this._fixedBody, room)));
     };
 }
 module.exports = Setup;
@@ -234,5 +234,5 @@ Setup.rclProperty = function(property) {
         }
 
         return creepSetup.SelfOrCall(rcl(room)[property], room);
-    }
+    };
 };

--- a/creep.setup.hauler.js
+++ b/creep.setup.hauler.js
@@ -8,18 +8,18 @@ setup.maxMulti = function(room) {
     let contSum = _.sum(room.structures.container.in, 'sum');
     contSum += _.sum(room.droppedResources, 'amount');
     max += Math.floor(contSum / 1000);
-    max += Creep.setup.upgrader.maxMulti(room);
+    max += Creep.setup.upgrader._maxMulti(room);
     return Math.min(max, 16);
 };
 setup.maxCount = function(room){
     if( !room.population ) return 0;
     let count = 0;
-    let miners = (room.population.typeCount['miner']||0);
-    let workers = (room.population.typeCount['worker']||0);
-    let mineralMiners = (room.population.typeCount['mineralMiner']||0);
+    let miners = (room.population.typeCount.miner || 0);
+    let workers = (room.population.typeCount.worker || 0);
+    let mineralMiners = (room.population.typeCount.mineralMiner || 0);
     let cont = room.structures.container.in.length + room.structures.links.storage.length;
     if( miners > 0  || ( cont > 0 && workers > 2 )) {
-        count += Creep.setup.upgrader.maxCount(room);
+        count += Creep.setup.upgrader._maxCount(room);
         if( room.structures.links.all.length < 3 ||
            (room.storage && room.storage.charge > 1 &&
             room.structures.container.controller && _.sum(room.structures.container.controller, 'store.energy') == 0 )) count++;
@@ -38,12 +38,12 @@ setup.maxCount = function(room){
         room.droppedResources.forEach(countNearSource);
         if(room.storage && dropped > 1000) count++;
         */
-        if( count == 0 ) count = 1;
+        if( count === 0 ) count = 1;
     }
     return count;
 };
 setup.maxWeight = function(room){
-    return setup.maxCount(room) * 2000;
+    return setup._maxCount(room) * 2000;
 };
 setup.default = {
     fixedBody: [WORK, CARRY, MOVE],

--- a/creep.setup.mineralMiner.js
+++ b/creep.setup.mineralMiner.js
@@ -1,9 +1,9 @@
 let setup = new Creep.Setup('mineralMiner');
 module.exports = setup;
 setup.minControllerLevel = 6;
-setup.maxCount = function(room){
+setup.maxCount = function(room) {
     let max = 0;
-    let haulers = (room.population.typeCount['hauler']||0);
+    let haulers = (room.population.typeCount.hauler || 0);
     if( haulers === 0 ) return 0;
     if( room.storage && room.storage.sum < room.storage.storeCapacity * 0.9 ) {
         let add = mineral => {

--- a/creep.setup.privateer.js
+++ b/creep.setup.privateer.js
@@ -9,7 +9,7 @@ setup.default = {
     minAbsEnergyAvailable: 400,
     minEnergyAvailable: 0.8,
     maxMulti: 15,
-    minMulti: (room) => (room.controller.level),
+    minMulti: (room) => room.controller.level,
     maxWeight: (room) => room.privateerMaxWeight
 };
 setup.RCL = {

--- a/creep.setup.upgrader.js
+++ b/creep.setup.upgrader.js
@@ -23,7 +23,7 @@ setup.maxCount = function(room){
             // Energy reserves are low
             room.conserveForDefense ||
             // No energy structures built near controller
-            (room.structures.container.controller.length + room.structures.links.controller.length) == 0 ||
+            (room.structures.container.controller.length + room.structures.links.controller.length) === 0 ||
             // Upgrading blocked -> http://support.screeps.com/hc/en-us/articles/207711889-StructureController#upgradeBlocked
             room.controller.upgradeBlocked
         ) return 0;

--- a/creep.setup.worker.js
+++ b/creep.setup.worker.js
@@ -13,8 +13,7 @@ setup.maxWorker = room => {
     if( !setup.hasMinerOrHauler(room))
         return 1;
     // constructionsites present & no strorage or storage > min
-    if( room.constructionSites.length > 0 && (!room.storage
-        || room.storage.store && room.storage.charge > 0))
+    if( room.constructionSites.length > 0 && (!room.storage || room.storage.store && room.storage.charge > 0))
         return 1;
     // storage full & base fortifyable
     if( room.storage && room.storage.charge > 1 && room.structures.fortifyable.length > 0 )
@@ -23,8 +22,8 @@ setup.maxWorker = room => {
 };
 // validates if there is a miner or a hauler present
 setup.hasMinerOrHauler = room => ( room.population &&
-    ((room.population.typeCount['hauler'] && room.population.typeCount['hauler'] > 0) ||
-    (room.population.typeCount['miner'] && room.population.typeCount['miner'] > 0 )));
+    ((room.population.typeCount.hauler && room.population.typeCount.hauler > 0) ||
+    (room.population.typeCount.miner && room.population.typeCount.miner > 0 )));
 // this assures that the first worker gets spawned immediately, but later workers require more energy, giving preference to miners
 setup.byPopulation = function(type, start, perBody, limit) {
     return function(room) {

--- a/creep.setup.worker.js
+++ b/creep.setup.worker.js
@@ -13,7 +13,8 @@ setup.maxWorker = room => {
     if( !setup.hasMinerOrHauler(room))
         return 1;
     // constructionsites present & no strorage or storage > min
-    if( room.constructionSites.length > 0 && (!room.storage || room.storage.store && room.storage.charge > 0))
+    if( room.constructionSites.length > 0 && (!room.storage
+        || room.storage.store && room.storage.charge > 0))
         return 1;
     // storage full & base fortifyable
     if( room.storage && room.storage.charge > 1 && room.structures.fortifyable.length > 0 )


### PR DESCRIPTION
This resolves some major inconsistencies with creep setup customization.

Hopefully this will help us realize the features needed for Task-based creep body definitions, or perhaps help us realize the ways we can extend and customize creep body definitions as we transition away from the Setup queue.