### PR TITLE
haulers and miners are vital spawns, and should be easy to spawn.

### DIFF
--- a/creep.setup.hauler.js
+++ b/creep.setup.hauler.js
@@ -54,6 +54,15 @@ setup.default = {
     maxCount: room => setup.maxCount(room),
     maxWeight: room => setup.maxWeight(room),
 };
+setup.high = {
+    fixedBody: [WORK, CARRY, MOVE],
+    multiBody: [CARRY, CARRY, MOVE],
+    minAbsEnergyAvailable: 200,
+    minEnergyAvailable: 0.2,
+    maxMulti: room => setup.maxMulti(room),
+    maxCount: room => setup.maxCount(room),
+    maxWeight: room => setup.maxWeight(room),
+};
 setup.RCL = {
     1: setup.none,
     2: setup.default,
@@ -62,5 +71,5 @@ setup.RCL = {
     5: setup.default,
     6: setup.default,
     7: setup.default,
-    8: setup.default
+    8: setup.high
 };

--- a/creep.setup.miner.js
+++ b/creep.setup.miner.js
@@ -17,6 +17,14 @@ setup.low = {
     maxMulti: 3,
     maxCount: room => room.sources.length,
 };
+setup.high = {
+    fixedBody: [WORK, WORK, WORK, WORK, CARRY, MOVE],
+    multiBody: [WORK, MOVE],
+    minAbsEnergyAvailable: 500,
+    minEnergyAvailable: 0.1,
+    maxMulti: 2,
+    maxCount: room => room.sources.length
+};
 setup.RCL = {
     1: setup.low,
     2: setup.low,
@@ -25,5 +33,5 @@ setup.RCL = {
     5: setup.default,
     6: setup.default,
     7: setup.default,
-    8: setup.default
+    8: setup.high
 };


### PR DESCRIPTION
RCL8 rooms are fragile because these are set too high.  If a room gets into 'collapsed' and only has the emergency worker to fill extensions, and then both miners die, no haulers can spawn.  With remote creeps still spawning the tiny worker has no real chance of getting energy capacity back up to the level that a hauler or miner could spawn.

Miner was set to 30% full, which is 3870 energy at RCL8
Hauler at 40% is 5160 which is also excessive.

This change sets the limit for miners to 1290 and haulers to 2580.