### PR TITLE
Increase desired weight of reservers

### DIFF
--- a/task.reserve.js
+++ b/task.reserve.js
@@ -5,7 +5,8 @@ mod.name = 'reserve';
 mod.creep = {
     reserver: {
         fixedBody: [CLAIM, CLAIM, MOVE, MOVE],
-        multiBody: [],
+        multiBody: [CLAIM, MOVE],
+        maxMulti: 7,
         name: "reserver", 
         behaviour: "claimer"
     },
@@ -234,7 +235,7 @@ mod.strategies = {
             // Don't spawn if...
             const hasFlag = !!flag;
             const hasController = Room.isControllerRoom(flag.pos.roomName) || (flag.room && flag.room.controller);
-            const hasReservation = (flag.room && flag.room.controller && flag.room.controller.reservation && (flag.room.controller.reservation.ticksToEnd > 2500 || flag.room.controller.reservation.username != myName) );
+            const hasReservation = (flag.room && flag.room.controller && flag.room.controller.reservation && (flag.room.controller.reservation.ticksToEnd > 1000 || flag.room.controller.reservation.username != myName) );
             const isOwned = (flag.room && flag.room.controller && flag.room.controller.owner);
             if( // Flag was removed
                 !hasFlag ||


### PR DESCRIPTION
Heavier reservers are more efficient, for CPU & Energy.

eg. assume 100 ticks travel, 400 ticks reserve
small: 2CLAIM,2MOVE
large: 4CLAIM,4MOVE
2xsmall = 200 ticks travel 800 ticks reserve = 1600 reserve (-800 ticks decay) ~ 800 reserve
1xlarge = 100 ticks travel 400 ticks reserve = 1600 reserve (-400 ticks decay) ~ 1200 reserve

this reduces the threshold to 1000, so for a nearby room the heaviest reserver would give us
9CLAIM, 9MOVE, 50 ticks travel 450 ticks reserve = 4050 - 450(decay) = 3600 building it up to ~ 4600.