### PR TITLE
storage debounce improved - hold withdrawing / storing until an output action target is available

### DIFF
--- a/creep.action.feeding.js
+++ b/creep.action.feeding.js
@@ -15,6 +15,9 @@ action.isAddableTarget = function(target){
         (!target.targetOf || _.filter(target.targetOf, {'actionName':'feeding'}).length < this.maxPerTarget));
 };
 action.newTarget = function(creep){
+    if (creep.room.energyAvailable === creep.room.energyCapacityAvailable) {
+        return null;
+    }
     var that = this;
     return creep.pos.findClosestByPath(creep.room.structures.all, {
         filter: (structure) => {

--- a/creep.action.withdrawing.js
+++ b/creep.action.withdrawing.js
@@ -22,3 +22,18 @@ action.onAssignment = function(creep, target) {
     //if( SAY_ASSIGNMENT ) creep.say(String.fromCharCode(9738), SAY_PUBLIC);
     if( SAY_ASSIGNMENT ) creep.say('\u{1F4E4}\u{FE0E}', SAY_PUBLIC);
 };
+action.debounce = function(creep, outflowActions, callback, thisArg) {
+    let shouldCall = false;
+    if (creep.data.lastAction === 'storing' && creep.data.lastTarget === creep.room.storage.id) {
+        // cycle detected
+        shouldCall = _.chain(outflowActions).invoke('newTarget', creep).some().value(); // cycle broken if valid target
+    } else {
+        shouldCall = true;
+    }
+
+    if (shouldCall) {
+        return _.invoke([thisArg], callback, this)[0];
+    }
+
+    return undefined;
+};

--- a/creep.behaviour.hauler.js
+++ b/creep.behaviour.hauler.js
@@ -20,28 +20,27 @@ mod.nextAction = function(creep){
         Creep.action.travelling.assign(creep, Game.rooms[creep.data.homeRoom].controller);
         return;
     }
-    let priority;
-    if( creep.sum < creep.carryCapacity/2 ) {
+    const outflowPriority = [
+        Creep.action.feeding,
+        Creep.action.charging,
+        Creep.action.fueling,
+    ];
+    let priority = outflowPriority;
+    if( creep.sum * 2 < creep.carryCapacity ) {
         priority = [
             Creep.action.uncharging,
-            Creep.action.picking];
-        let potentialFuelTarget = Creep.action.fueling.newTarget(creep);
-        let potentialChargeTarget = Creep.action.charging.newTarget(creep);
-        if( creep.data.lastAction !== 'storing' || !creep.room.storage || creep.data.lastTarget !== creep.room.storage.id ||
-            creep.room.relativeEnergyAvailable < 1.0 || potentialFuelTarget !== null ||
-                ( potentialChargeTarget && ( (potentialChargeTarget.structureType === STRUCTURE_LINK) ? true : ( potentialChargeTarget.storeCapacity - potentialChargeTarget.sum ) >  Math.min( creep.carryCapacity, 500 ) ) ) ) {
-            priority.push(Creep.action.withdrawing);
-        }
+            Creep.action.picking,
+        ];
+        Creep.action.withdrawing.debounce(creep, outflowPriority, function(withdrawing) {
+            priority.push(withdrawing);
+        });
         priority.push(Creep.action.reallocating);
         priority.push(Creep.action.idle);
-    }
-    else {
-        priority = [
-            Creep.action.feeding,
-            Creep.action.charging,
-            Creep.action.fueling,
+    } else {
+        priority = outflowPriority.concat([
             Creep.action.storing,
-            Creep.action.idle];
+            Creep.action.idle,
+        ]);
         if ( creep.sum > creep.carry.energy ||
             ( !creep.room.situation.invasion
             && SPAWN_DEFENSE_ON_ATTACK


### PR DESCRIPTION
This is very similar to your implementation @logxen but I wanted to clean it up and make room for a standard impl that uses our APIs.