### PR TITLE
haulers should fill the closest towers first.

### DIFF
--- a/creep.action.fueling.js
+++ b/creep.action.fueling.js
@@ -13,7 +13,7 @@ action.isAddableTarget = function(target){
         (!target.targetOf || target.targetOf.length < this.maxPerTarget));
 };
 action.newTarget = function(creep){
-    return creep.room.structures.fuelable.length > 0 ? creep.room.structures.fuelable[0] : null;
+    return creep.room.structures.fuelable.length > 0 ? creep.pos.findClosestByRange(creep.room.structures.fuelable) : null;
 };
 action.work = function(creep){
     let response = creep.transfer(creep.target, RESOURCE_ENERGY);


### PR DESCRIPTION
At some point we should update fueling so that they fill towers based on their proximity to hostiles, but this stops them from walking across your room to fill 1 tower and making the invasion even worse.