### PR TITLE
RCL8 Upgraders spawn in time to replace and at the right size.

### DIFF
--- a/creep.setup.upgrader.js
+++ b/creep.setup.upgrader.js
@@ -71,8 +71,8 @@ setup.low = {
 setup.level8 = {
     fixedBody: [CARRY, MOVE, MOVE, MOVE],
     multiBody: [WORK],
-    minAbsEnergyAvailable: 300,
-    minEnergyAvailable: 1,
+    minAbsEnergyAvailable: 1700,
+    minEnergyAvailable: 0.5,
     maxMulti: CONTROLLER_MAX_UPGRADE_PER_TICK / UPGRADE_CONTROLLER_POWER,
     maxCount: room => setup.maxCount(room),
 };


### PR DESCRIPTION
Lowered the threshold for spawn because filling all of the extensions at RCL8 can take quite a long time, and really isn't necessary.