### PR TITLE
attempt to check for circular references before the backend find them

### DIFF
--- a/task.mining.js
+++ b/task.mining.js
@@ -475,6 +475,7 @@ mod.strategies = {
         name: `default-${mod.name}`,
     },
     reserve: {
+        name: `reserve-${mod.name}`,
         spawnParams: function(flag) {
             const population = mod.carryPopulation(flag.pos.roomName);
 


### PR DESCRIPTION
Guess what... this one will throw an exception. BECAUSE we want to halt execution before the engine can mess us up.

Not sure what I should do to repair these circulars until I see one. I might be able to delete the keys after we gather a few samples.

This is disabled by default. In order to enable it you MUST add the following code to your viral.mainInjection.js
```
mod.execute = function(){
    Population.findCircular();
};
```