### PR TITLE
Save collapsed RCL8 Rooms

### DIFF
--- a/creep.setup.hauler.js
+++ b/creep.setup.hauler.js
@@ -58,7 +58,7 @@ setup.high = {
     fixedBody: [WORK, CARRY, MOVE],
     multiBody: [CARRY, CARRY, MOVE],
     minAbsEnergyAvailable: 200,
-    minEnergyAvailable: 0.2,
+    minEnergyAvailable: 0.1,
     maxMulti: room => setup.maxMulti(room),
     maxCount: room => setup.maxCount(room),
     maxWeight: room => setup.maxWeight(room),


### PR DESCRIPTION
An RCL8 room with an emergency worker struggles to get up to 2600 energy, but if you can spawn one with ~ 1300 it will get the room back into good shape very quickly