### PR TITLE
[WIP] rooms with excess energy will now offload via terminal

### DIFF
--- a/extensions.js
+++ b/extensions.js
@@ -260,9 +260,9 @@ mod.extend = function(){
         if (terminalData) order = terminalData.orders.find((o)=>{return o.type==resourceType;});
         if (!order) order = { orderAmount: 0, orderRemaining: 0, storeAmount: 0 };
         let loadTarget = Math.max(order.orderRemaining + (this.store[resourceType]||0), order.storeAmount + ((resourceType == RESOURCE_ENERGY) ? TERMINAL_ENERGY : 0));
-        if (resourceType === RESOURCE_ENERGY && this.room.storage.store[RESOURCE_ENERGY > MAX_STORAGE_ENERGY]) {
+        if (resourceType === RESOURCE_ENERGY && this.room.storage.store[RESOURCE_ENERGY] > MAX_STORAGE_ENERGY) {
             const rcl = this.room.controller.level;
-            loadTarget = Math.min(55000, Math.max(loadTarget, this.room.storage.store[RESOURCE_ENERGY] - MAX_STORAGE_ENERGY[rcl]));
+            loadTarget = Math.min(60000, Math.max(loadTarget, this.room.storage.store[RESOURCE_ENERGY] - MAX_STORAGE_ENERGY[rcl]));
         }
         let unloadTarget = order.orderAmount + order.storeAmount + ((resourceType == RESOURCE_ENERGY) ? TERMINAL_ENERGY : 0);
         if (unloadTarget < 0) unloadTarget = 0;

--- a/extensions.js
+++ b/extensions.js
@@ -262,7 +262,7 @@ mod.extend = function(){
         let loadTarget = Math.max(order.orderRemaining + (this.store[resourceType]||0), order.storeAmount + ((resourceType == RESOURCE_ENERGY) ? TERMINAL_ENERGY : 0));
         if (resourceType === RESOURCE_ENERGY && this.room.storage.store[RESOURCE_ENERGY] > MAX_STORAGE_ENERGY) {
             const rcl = this.room.controller.level;
-            loadTarget = Math.min(60000, Math.max(loadTarget, this.room.storage.store[RESOURCE_ENERGY] - MAX_STORAGE_ENERGY[rcl]));
+            loadTarget = Math.min(150000, Math.max(loadTarget, this.room.storage.store[RESOURCE_ENERGY] - MAX_STORAGE_ENERGY[rcl]));
         }
         let unloadTarget = order.orderAmount + order.storeAmount + ((resourceType == RESOURCE_ENERGY) ? TERMINAL_ENERGY : 0);
         if (unloadTarget < 0) unloadTarget = 0;

--- a/extensions.js
+++ b/extensions.js
@@ -260,6 +260,10 @@ mod.extend = function(){
         if (terminalData) order = terminalData.orders.find((o)=>{return o.type==resourceType;});
         if (!order) order = { orderAmount: 0, orderRemaining: 0, storeAmount: 0 };
         let loadTarget = Math.max(order.orderRemaining + (this.store[resourceType]||0), order.storeAmount + ((resourceType == RESOURCE_ENERGY) ? TERMINAL_ENERGY : 0));
+        if (resourceType === RESOURCE_ENERGY && this.room.storage.store[RESOURCE_ENERGY > MAX_STORAGE_ENERGY]) {
+            const rcl = this.room.controller.level;
+            loadTarget = Math.min(55000, Math.max(loadTarget, this.room.storage.store[RESOURCE_ENERGY] - MAX_STORAGE_ENERGY[rcl]));
+        }
         let unloadTarget = order.orderAmount + order.storeAmount + ((resourceType == RESOURCE_ENERGY) ? TERMINAL_ENERGY : 0);
         if (unloadTarget < 0) unloadTarget = 0;
         let store = this.store[resourceType]||0;

--- a/room.js
+++ b/room.js
@@ -1485,7 +1485,16 @@ mod.extend = function(){
         }
     };
     Room.prototype.updateRoomOrders = function () {
-        if (!this.memory.resources || !this.memory.resources.orders) return;
+        if (this.memory.resources === undefined) {
+            this.memory.resources = {
+                lab: [],
+                container: [],
+                terminal: [],
+                storage: [],
+                powerSpawn: [],
+            };
+        }
+        if (!this.memory.resources.orders) return;
         let rooms = _.filter(Game.rooms, (room) => { return room.my && room.storage && room.terminal && room.name !== this.name; });
         let orders = this.memory.resources.orders;
         for (let i=0;i<orders.length;i++) {
@@ -1513,15 +1522,6 @@ mod.extend = function(){
                 rooms.sort((a,b)=>{ return Game.map.getRoomLinearDistance(this.name,a.name,true) - Game.map.getRoomLinearDistance(this.name,b.name,true); });
                 for (let j=0;j<rooms.length;j++) {
                     let room = rooms[j];
-                    if (room.memory.resources === undefined) {
-                        room.memory.resources = {
-                            lab: [],
-                            container: [],
-                            terminal: [],
-                            storage: [],
-                            powerSpawn: [],
-                        };
-                    }
                     let available = (room.storage.store[order.type]||0) + (room.terminal.store[order.type]||0);
                     if (available < 100) continue;
                     available = Math.min(available,amountRemaining);
@@ -1673,7 +1673,7 @@ mod.extend = function(){
                 //room.controller.level < 8 &&
                 room.storage && room.terminal &&
                 room.terminal.sum < room.terminal.storeCapacity - 50000 &&
-                room.storage.sum < room.storage.storeCapacity * 0.6 &&
+                room.storage.charge < 0.6 &&
                 !room._isReceivingEnergy
             )
             let targetRoom = _.min(_.filter(Game.rooms, requiresEnergy), 'storage.store.energy');


### PR DESCRIPTION
I manually set TERMINAL_ENERGY to 0 so that my rooms won't hoard energy in the terminals, but it exposed the fact that my full rooms weren't loading up terminals to transfer.  This should fix that.