### PR TITLE
Implement picking strategy for haulers and remoteHaulers

### DIFF
--- a/creep.Action.js
+++ b/creep.Action.js
@@ -121,8 +121,9 @@ let Action = function(actionName){
     this.selectStrategies = function() {
         return [this.defaultStrategy];
     };
-    this.getStrategy = function(strategyName, creep, args = []) {
-        return creep.getStrategyHandler([this.name], strategyName, args);
+    this.getStrategy = function(strategyName, creep, args) {
+        if (_.isUndefined(args)) return creep.getStrategyHandler([this.name], strategyName);
+        else return creep.getStrategyHandler([this.name], strategyName, args);
     };
 };
 module.exports = Action;

--- a/creep.Action.js
+++ b/creep.Action.js
@@ -121,5 +121,8 @@ let Action = function(actionName){
     this.selectStrategies = function() {
         return [this.defaultStrategy];
     };
+    this.getStrategy = function(strategyName, creep, args = []) {
+        return creep.getStrategyHandler([this.name], strategyName, args);
+    };
 };
 module.exports = Action;

--- a/creep.action.picking.js
+++ b/creep.action.picking.js
@@ -20,7 +20,6 @@ action.isAddableTarget = function(target, creep){
     return (!target.targetOf || !pickers.length || ((pickers.length < max) && target.amount > _.sum( pickers.map( t => t.carryCapacityLeft))));
 };
 action.newTarget = function(creep){
-    console.log(creep.name, 'energyOnly', action.getStrategy('energyOnly', creep));
     const droppedResources = action.getStrategy('energyOnly', creep) ? _.filter(creep.room.droppedResources, {resourceType: RESOURCE_ENERGY}) : creep.room.droppedResources;
     let filter;
     if( creep.room.my && creep.room.situation.invasion ) {

--- a/creep.action.picking.js
+++ b/creep.action.picking.js
@@ -20,28 +20,16 @@ action.isAddableTarget = function(target, creep){
     return (!target.targetOf || !pickers.length || ((pickers.length < max) && target.amount > _.sum( pickers.map( t => t.carryCapacityLeft))));
 };
 action.newTarget = function(creep){
-    let target;
+    console.log(creep.name, 'energyOnly', action.getStrategy('energyOnly', creep));
+    const droppedResources = action.getStrategy('energyOnly', creep) ? _.filter(creep.room.droppedResources, {resourceType: RESOURCE_ENERGY}) : creep.room.droppedResources;
+    let filter;
     if( creep.room.my && creep.room.situation.invasion ) {
         // pickup near sources only
-        target = creep.pos.findClosestByPath(creep.room.droppedResources, {
-            filter: (o) => this.isAddableTarget(o, creep) && o.pos.findInRange(creep.room.sources, 1).length > 0
-        });
+        filter = (r) => this.isAddableTarget(r, creep) && r.pos.findInRange(creep.room.sources, 1).length > 0;
     } else {
-        if ( creep.room.storage && creep.room.storage.my ) {
-            target = creep.pos.findClosestByPath(creep.room.droppedResources, {
-                filter: (o) => ( o.resourceType != RESOURCE_ENERGY && this.isAddableTarget(o, creep))
-            });
-
-            if( !target ) target = creep.pos.findClosestByPath(creep.room.droppedResources, {
-                filter: (o) => this.isAddableTarget(o, creep)
-            });
-        } else {
-            target = creep.pos.findClosestByPath(creep.room.droppedResources, {
-                filter: (o) => ( o.resourceType == RESOURCE_ENERGY && this.isAddableTarget(o, creep))
-            });
-        }
+        filter = (r) => this.isAddableTarget(r, creep);
     }
-    return target;
+    return creep.pos.findClosestByPath(droppedResources, {filter: filter});
 };
 action.work = function(creep){
     var result = creep.pickup(creep.target);
@@ -78,3 +66,4 @@ action.work = function(creep){
 action.onAssignment = function(creep, target) {
     if( SAY_ASSIGNMENT ) creep.say(String.fromCharCode(8681), SAY_PUBLIC);
 };
+action.defaultStrategy.energyOnly = true;

--- a/creep.behaviour.hauler.js
+++ b/creep.behaviour.hauler.js
@@ -62,3 +62,15 @@ mod.nextAction = function(creep){
         }
     }
 };
+mod.selectStrategies = function(actionName) {
+    return [mod.strategies.defaultStrategy, mod.strategies[actionName]];
+};
+mod.strategies = {
+    defaultStrategy: {
+        name: `default-${mod.name}`
+    },
+    picking: {
+        name: `picking-${mod.name}`,
+        energyOnly: false
+    }
+};

--- a/creep.behaviour.remoteHauler.js
+++ b/creep.behaviour.remoteHauler.js
@@ -97,3 +97,15 @@ mod.gotoTargetRoom = function(creep){
 mod.goHome = function(creep){
     return Creep.action.travelling.assignRoom(creep, creep.data.homeRoom);
 };
+mod.selectStrategies = function(actionName) {
+    return [mod.strategies.defaultStrategy, mod.strategies[actionName]];
+};
+mod.strategies = {
+    defaultStrategy: {
+        name: `default-${mod.name}`
+    },
+    picking: {
+        name: `picking-${mod.name}`,
+        energyOnly: false
+    }
+};

--- a/strategy.js
+++ b/strategy.js
@@ -16,7 +16,7 @@ mod.decorateAgent = function(prototype, ...definitions) {
             logError('strategy handler returned undefined', {agent: this.name || this.id, strategyKey, strategyName, method, stack: new Error().stack});
             return;
         }
-        if (args.length === 0) {
+        if (_.size(args.length) === 0) {
             return returnValOrMethod;
         }
         const returnVal = returnValOrMethod.apply(this.currentStrategy, args);

--- a/strategy.js
+++ b/strategy.js
@@ -16,7 +16,7 @@ mod.decorateAgent = function(prototype, ...definitions) {
             logError('strategy handler returned undefined', {agent: this.name || this.id, strategyKey, strategyName, method, stack: new Error().stack});
             return;
         }
-        if (_.size(args) === 0) {
+        if (args.length === 0) {
             return returnValOrMethod;
         }
         const returnVal = returnValOrMethod.apply(this.currentStrategy, args);

--- a/strategy.js
+++ b/strategy.js
@@ -16,7 +16,7 @@ mod.decorateAgent = function(prototype, ...definitions) {
             logError('strategy handler returned undefined', {agent: this.name || this.id, strategyKey, strategyName, method, stack: new Error().stack});
             return;
         }
-        if (_.size(args.length) === 0) {
+        if (_.size(args) === 0) {
             return returnValOrMethod;
         }
         const returnVal = returnValOrMethod.apply(this.currentStrategy, args);


### PR DESCRIPTION
Defines the default strategy for picking to only pick energy, currently this strategy is only overridden for haulers and remoteHaulers to allow them to pick resources as well as energy.