### PR TITLE
test for valid flag on dropping assignment

### DIFF
--- a/creep.action.dropping.js
+++ b/creep.action.dropping.js
@@ -8,8 +8,7 @@ action.isValidAction = function(creep){
 action.isValidTarget = function(target, creep){
     if (!target) return false;
     if (target instanceof Flag) {
-        return _.eq(target, FlagDir.flagFilter(FLAG_COLOR.claim.spawn)) ||
-                _.eq(target, FlagDir.flagFilter(FLAG_COLOR.command.drop));
+        return target.compareTo(FLAG_COLOR.claim.spawn) || target.compareTo(FLAG_COLOR.command.drop);
     }
     return true;
 };
@@ -22,7 +21,7 @@ action.newTarget = function(creep) {
     if( !drop ) {
         drop = creep.pos.findClosestByRange(creep.room.find(FIND_FLAGS, FlagDir.flagFilter(FLAG_COLOR.claim.spawn)));
     }
-    return drop || false;
+    return drop;
 };
 action.work = function(creep) {
     let ret = OK;

--- a/creep.action.dropping.js
+++ b/creep.action.dropping.js
@@ -5,6 +5,14 @@ action.reachedRange = 0;
 action.isValidAction = function(creep){
     return creep.sum > 0;
 };
+action.isValidTarget = function(target, creep){
+    if (!target) return false;
+    if (target instanceof Flag) {
+        return _.eq(target, FlagDir.flagFilter(FLAG_COLOR.claim.spawn)) ||
+                _.eq(target, FlagDir.flagFilter(FLAG_COLOR.command.drop));
+    }
+    return true;
+};
 action.newTarget = function(creep) {
     // drop off at drop pile or the nearest spawn
     let drop = creep.pos.findClosestByRange(creep.room.structures.piles);
@@ -14,7 +22,7 @@ action.newTarget = function(creep) {
     if( !drop ) {
         drop = creep.pos.findClosestByRange(creep.room.find(FIND_FLAGS, FlagDir.flagFilter(FLAG_COLOR.claim.spawn)));
     }
-    return drop;
+    return drop || false;
 };
 action.work = function(creep) {
     let ret = OK;


### PR DESCRIPTION
might need some help on this one. I've got a quick test that halts broken haulers and sets them in the right direction but I haven't tested the outcome or the normal operation of this fix

this prevents creeps with the dropping action from being assigned to any old flag... still not sure how they get assigned to these flags