### PR TITLE
delete Memory.modules would not actually rebuild modules

### DIFF
--- a/global.js
+++ b/global.js
@@ -424,7 +424,6 @@ mod.memoryUsage = function(key) {
     string += `<tr><td>Total</td><td>${_.round(total, 2)}</td></tr></table>`;
     return string;
 };
-mod.profiler = null;
 mod.resetProfiler = function() {
     mod.loadProfiler(true);
 };

--- a/main.js
+++ b/main.js
@@ -244,10 +244,7 @@ module.exports.loop = function () {
 
     // ensure required memory namespaces
     if (Memory.modules === undefined)  {
-        Memory.modules = {
-            viral: {},
-            internalViral: {}
-        };
+        global.install();
     }
     if (Memory.debugTrace === undefined) {
         Memory.debugTrace = {error:true, no:{}};


### PR DESCRIPTION
 until the code gets reloaded.  This ensures that it gets properly rebuilt.

Needs to be investigated whether this is also an issue in https://github.com/ScreepsOCS/screeps.behaviour-action-pattern/pull/960

Yes, this would appear to also be an issue in the RC, if this change is approved, the change to add global.install() should be added, but not the patch for fixing an error with the profiling loading.