### PR TITLE
infectiousMemory - Change parameters in memory without reloading all code

### DIFF
--- a/main.js
+++ b/main.js
@@ -262,8 +262,11 @@ module.exports.loop = function () {
     if (Memory.cloaked === undefined) {
         Memory.cloaked = {};
     }
+    
+    Util.set(Memory, 'parameters', {});
+    _.assign(global, {parameters: Memory.parameters}); // allow for shorthand access in console
     // ensure up to date parameters, override in memory
-    _.assign(global, load("parameter", Memory.parameters));
+    _.assign(global, load("parameter", parameters));
    
     // process loaded memory segments
     OCSMemory.processSegments();

--- a/main.js
+++ b/main.js
@@ -260,7 +260,8 @@ module.exports.loop = function () {
     }
     // ensure up to date parameters
     _.assign(global, load("parameter"));
-    
+    _.assign(global, Memory.parameters);
+   
     // process loaded memory segments
     OCSMemory.processSegments();
     p.checkCPU('processSegments', PROFILING.ANALYZE_LIMIT);

--- a/main.js
+++ b/main.js
@@ -93,7 +93,8 @@ global.infect = (mod, namespace, modName) => {
 };
 // loads (require) a module. use this function anywhere you want to load a module.
 // respects custom and viral overrides
-global.load = (modName) => {
+// @param memory - optional memory to override members with
+global.load = (modName, memory) => {
     // read stored module path
     let path = getPath(modName);
     // try to load module
@@ -108,6 +109,9 @@ global.load = (modName) => {
         // load viral overrides 
         mod = infect(mod, 'internalViral', modName);
         mod = infect(mod, 'viral', modName);
+    }
+    if (memory) {
+        global.inject(mod, memory);
     }
     return mod;
 };
@@ -258,9 +262,8 @@ module.exports.loop = function () {
     if (Memory.cloaked === undefined) {
         Memory.cloaked = {};
     }
-    // ensure up to date parameters
-    _.assign(global, load("parameter"));
-    _.assign(global, Memory.parameters);
+    // ensure up to date parameters, override in memory
+    _.assign(global, load("parameter", Memory.parameters));
    
     // process loaded memory segments
     OCSMemory.processSegments();

--- a/main.js
+++ b/main.js
@@ -93,8 +93,7 @@ global.infect = (mod, namespace, modName) => {
 };
 // loads (require) a module. use this function anywhere you want to load a module.
 // respects custom and viral overrides
-// @param memory - optional memory to override members with
-global.load = (modName, memory) => {
+global.load = (modName) => {
     // read stored module path
     let path = getPath(modName);
     // try to load module
@@ -109,9 +108,6 @@ global.load = (modName, memory) => {
         // load viral overrides 
         mod = infect(mod, 'internalViral', modName);
         mod = infect(mod, 'viral', modName);
-    }
-    if (memory) {
-        global.inject(mod, memory);
     }
     return mod;
 };
@@ -266,7 +262,8 @@ module.exports.loop = function () {
     Util.set(Memory, 'parameters', {});
     _.assign(global, {parameters: Memory.parameters}); // allow for shorthand access in console
     // ensure up to date parameters, override in memory
-    _.assign(global, load("parameter", parameters));
+    _.assign(global, load("parameter"));
+    _.merge(global, parameters);
    
     // process loaded memory segments
     OCSMemory.processSegments();


### PR DESCRIPTION
Set values in Memory.parameters which will override values in parameter.js.  Ideally, Memory.parameters should be deleted whenever new code is pushed, but currently we can't detect the difference between a code push and an instance switch.