### PR TITLE
Fix/attack controller

### DIFF
--- a/creep.action.attackController.js
+++ b/creep.action.attackController.js
@@ -1,7 +1,7 @@
 let action = new Creep.Action('attackController');
 module.exports = action;
 action.isValidAction = function(creep){ return true; }; 
-action.isValidTarget = function(target){ return target && (!target.reservation || target.reservation !== ME) && creep.flag; };
+action.isValidTarget = function(target){ return target && (!target.reservation || !Task.reputation.allyOwner(target.reservation)) && creep.flag; };
 action.isAddableAction = function(){ return true; };
 action.isAddableTarget = function(target){ return target &&
     ( target instanceof Flag || ( target.structureType === 'controller' && (target.reservation || target.owner)) ); 
@@ -52,7 +52,8 @@ action.work = function(creep){
 
     creep.controllerSign();
 
-    if( creep.target.owner && !creep.target.my ){
+    if( (creep.target.owner && !creep.target.my) ||
+        (creep.target.reservation && !Task.reputation.allyOwner(creep.target.reservation))){
         workResult = creep.attackController(creep.target);
     }
     else {

--- a/creep.action.attackController.js
+++ b/creep.action.attackController.js
@@ -1,10 +1,10 @@
 let action = new Creep.Action('attackController');
 module.exports = action;
 action.isValidAction = function(creep){ return true; }; 
-action.isValidTarget = function(target){ return target && (!target.reservation ); };
+action.isValidTarget = function(target){ return target && (!target.reservation || target.reservation !== ME); };
 action.isAddableAction = function(){ return true; };
 action.isAddableTarget = function(target){ return target &&
-    ( target instanceof Flag || ( target.structureType === 'controller' && target.owner ) ); 
+    ( target instanceof Flag || ( target.structureType === 'controller' && (target.reservation || target.owner)) ); 
 };
 action.newTarget = function(creep){
     let validColor = flagEntry => (
@@ -43,8 +43,9 @@ action.step = function(creep){
         if( workResult != OK ) {
             creep.handleError({errorCode:workResult,action,target:creep.target,range,creep});
         }
+    } else {
+        creep.travelTo(creep.target);
     }
-    creep.travelTo(creep.target);
 };
 action.work = function(creep){
     var workResult;

--- a/creep.action.attackController.js
+++ b/creep.action.attackController.js
@@ -1,7 +1,7 @@
 let action = new Creep.Action('attackController');
 module.exports = action;
 action.isValidAction = function(creep){ return true; }; 
-action.isValidTarget = function(target){ return target && (!target.reservation || target.reservation !== ME); };
+action.isValidTarget = function(target){ return target && (!target.reservation || target.reservation !== ME) && creep.flag; };
 action.isAddableAction = function(){ return true; };
 action.isAddableTarget = function(target){ return target &&
     ( target instanceof Flag || ( target.structureType === 'controller' && (target.reservation || target.owner)) ); 

--- a/room.js
+++ b/room.js
@@ -2933,7 +2933,8 @@ mod.findSpawnRoom = function(params){
     if( !params || !params.targetRoom ) return null;
     // filter validRooms
     let isValidRoom = room => (
-        room.my &&
+        room.my && 
+        (params.maxRange === undefined || Util.routeRange(room.name, params.targetRoom) < params.maxRange) &&
         (params.minEnergyCapacity === undefined || params.minEnergyCapacity <= room.energyCapacityAvailable) &&
         (params.minEnergyAvailable === undefined || params.minEnergyAvailable <= room.energyAvailable) &&
         (room.name != params.targetRoom || params.allowTargetRoom === true) &&

--- a/room.js
+++ b/room.js
@@ -2934,7 +2934,7 @@ mod.findSpawnRoom = function(params){
     // filter validRooms
     let isValidRoom = room => (
         room.my && 
-        (params.maxRange === undefined || Util.routeRange(room.name, params.targetRoom) < params.maxRange) &&
+        (params.maxRange === undefined || Util.routeRange(room.name, params.targetRoom) <= params.maxRange) &&
         (params.minEnergyCapacity === undefined || params.minEnergyCapacity <= room.energyCapacityAvailable) &&
         (params.minEnergyAvailable === undefined || params.minEnergyAvailable <= room.energyAvailable) &&
         (room.name != params.targetRoom || params.allowTargetRoom === true) &&

--- a/task.attackController.js
+++ b/task.attackController.js
@@ -30,7 +30,8 @@ mod.checkForRequiredCreeps = (flag) => {
             }, 
             { // spawn room selection params
                 targetRoom: flag.pos.roomName, 
-                minEnergyCapacity: 9750
+                minEnergyCapacity: 9750,
+                maxRange: 5
             },
             creepSetup => { // onQueued callback
                     memory.queued.push({


### PR DESCRIPTION
attackController had a few issues that this should resolve.

It sets a maxRange on the spawn so your creeps don't spawn so far away that they immediately invalidate and trigger a new spawn. It seems that maxRange was completely missing, even though it was listed in the comments?

Correctly allow it to target either reservation or downgrade.