### PR TITLE
Boosting Action

### DIFF
--- a/creep.action.boosting.js
+++ b/creep.action.boosting.js
@@ -43,9 +43,12 @@ const action = class extends Creep.Action {
         // target is lab
         return target instanceof StructureLab &&
             // target has the minimum energy and mineral
-            target.energy >= LAB_BOOST_ENERGY && target.mineralAmount >= LAB_BOOST_MINERAL &&
-            // mineralType is a boosting compound
-            this.isValidMineralType(target.mineralType) &&
+            target.energy >= LAB_BOOST_ENERGY && target.mineralAmount >= LAB_BOOST_MINERAL;
+    }
+    
+    isAddableTarget(target, creep) {
+        // mineralType is a boosting compound
+        return super.isAddableTarget(target, creep) && this.isValidMineralType(target.mineralType) &&
             // creep has active body parts matching the mineralType's boost
             creep.hasActiveBodyparts(this.getBoostPartType(target.mineralType)) &&
             // can further boost parts of the mineralType's boost

--- a/creep.action.boosting.js
+++ b/creep.action.boosting.js
@@ -47,12 +47,13 @@ const action = class extends Creep.Action {
     }
     
     isAddableTarget(target, creep) {
+        const boostPartType = this.getBoostPartType(target.mineralType);
         // mineralType is a boosting compound
         return super.isAddableTarget(target, creep) && this.isValidMineralType(target.mineralType) &&
             // creep has active body parts matching the mineralType's boost
-            creep.hasActiveBodyparts(this.getBoostPartType(target.mineralType)) &&
+            creep.hasActiveBodyparts(boostPartType) &&
             // can further boost parts of the mineralType's boost
-            this.canBoostType(creep, this.getBoostPartType(target.mineralType));
+            this.canBoostType(creep, boostPartType);
     }
     
     newTarget(creep) {

--- a/creep.action.boosting.js
+++ b/creep.action.boosting.js
@@ -1,0 +1,70 @@
+const action = class extends Creep.Action {
+
+    constructor(...args) {
+        super(...args);
+        
+        this.maxPerAction = 1;
+        this.targetRange = 2;
+    }
+    
+    /**
+     * Check to see if the mineralType has a boost
+     */
+    isValidMineralType(mineralType) {
+        for (const category in BOOSTS) {
+            for (const compound in BOOSTS[category]) {
+                if (mineralType === compound) return true;
+            }
+        }
+        return false;
+    }
+    
+    /**
+     * Gets the part type matching the compound's boost
+     */
+    getBoostPartType(mineralType) {
+        for (const category in BOOSTS) {
+            for (const compound in BOOSTS[category]) {
+                if (mineralType === compound) return category;
+            }
+        }
+    }
+    
+    canBoostType(creep, type) {
+        return !_(creep.body).filter({type}).every(part => part.boost);
+    }
+    
+    isValidAction(creep) {
+        // only valid if not every part is boosted
+        return !_.every(creep.body, part => part.boost);
+    }
+    
+    isValidTarget(target, creep) {
+        // target is lab
+        return target instanceof StructureLab &&
+            // target has the minimum energy and mineral
+            target.energy >= LAB_BOOST_ENERGY && target.mineralAmount >= LAB_BOOST_MINERAL &&
+            // mineralType is a boosting compound
+            this.isValidMineralType(target.mineralType) &&
+            // creep has active body parts matching the mineralType's boost
+            creep.hasActiveBodyparts(this.getBoostPartType(target.mineralType)) &&
+            // can further boost parts of the mineralType's boost
+            this.canBoostType(creep, this.getBoostPartType(target.mineralType));
+    }
+    
+    newTarget(creep) {
+        return _(creep.room.structures.all)
+            .filter(this.isValidTarget)
+            .min(lab => creep.pos.getRangeTo(lab));
+    }
+    
+    work(creep) {
+        return creep.target.boostCreep(creep);
+    }
+    
+    onAssignment(creep) {
+        if (SAY_ASSIGNMENT) creep.say(ACTION_SAY.BOOSTING, SAY_PUBLIC);
+    }
+
+};
+module.exports = new action('boosting');

--- a/main.js
+++ b/main.js
@@ -160,6 +160,7 @@ global.install = () => {
         action: {
             attackController: load("creep.action.attackController"),
             avoiding: load("creep.action.avoiding"),
+            boosting: load('creep.action.boosting'),
             building: load("creep.action.building"),
             bulldozing: load('creep.action.bulldozing'),
             charging: load("creep.action.charging"),

--- a/parameter.js
+++ b/parameter.js
@@ -172,6 +172,7 @@ let mod = {
     ACTION_SAY: { // what gets said on creep.action.*.onAssignment
         ATTACK_CONTROLLER: String.fromCodePoint(0x1F5E1) + String.fromCodePoint(0x26F3), // 🗡⛳
         AVOIDING: String.fromCodePoint(0x21A9), // ↩
+        BOOSTING: String.fromCodePoint(0x1F37A), // 🍺
         BUILDING: String.fromCodePoint(0x2692), // ⚒
         BULLDOZING: String.fromCodePoint(0x1F69C), // 🚜
         CHARGING: String.fromCodePoint(0x1F50C), // 🔌


### PR DESCRIPTION
In it's current state, any creeps assigned this action will look for any labs in the room with a compound that has a boost for the creep's part(s).

If I can find out how @logxen did the lab stuff, I could filter out any "outgoing" labs.