### PR TITLE
withdrawingTargets - use terminal as valid withdraw when charge > 1 and don't debounce terminal

### DIFF
--- a/creep.action.withdrawing.js
+++ b/creep.action.withdrawing.js
@@ -27,9 +27,9 @@ action.work = function(creep){
     return creep.withdraw(creep.target, RESOURCE_ENERGY);
 };
 action.assignDebounce = function(creep, outflowActions) {
-    const target = action.newTarget(creep);
-    if (target) {
-        if (target instanceof StructureStorage && creep.data.lastAction === 'storing' && creep.data.lastTarget === creep.room.storage.id) {
+    const withdrawTarget = action.newTarget(creep);
+    if (withdrawTarget) {
+        if (withdrawTarget instanceof StructureStorage && creep.data.lastAction === 'storing' && creep.data.lastTarget === creep.room.storage.id) {
             // cycle detected
             const dummyCreep = {
                 carry:{},
@@ -41,21 +41,21 @@ action.assignDebounce = function(creep, outflowActions) {
             const stored = creep.room.storage.store[RESOURCE_ENERGY];
             const maxWithdraw = stored > creep.carryCapacity ? creep.carryCapacity : stored;
             dummyCreep.carry[RESOURCE_ENERGY] = maxWithdraw; // assume we get a full load of energy
-            let target = null;
+            let nextTarget = null;
             const validAction = _.find(outflowActions, a => {
                 if (a.name !== 'storing' && a.isValidAction(dummyCreep) && a.isAddableAction(dummyCreep)) {
-                    target = a.newTarget(dummyCreep);
-                    return !!target;
+                    nextTarget = a.newTarget(dummyCreep);
+                    return !!nextTarget;
                 }
                 return false;
             });
-            if (validAction && action.assign(creep, target)) {
+            if (validAction && action.assign(creep, withdrawTarget)) {
                 creep.data.nextAction = validAction.name;
-                creep.data.nextTarget = target.id;
+                creep.data.nextTarget = nextTarget.id;
                 return true;
             }
         } else {
-            return action.assign(creep, target);
+            return action.assign(creep, withdrawTarget);
         }
     }
     return false;

--- a/creep.action.withdrawing.js
+++ b/creep.action.withdrawing.js
@@ -13,41 +13,50 @@ action.isValidTarget = function(target){
     if (target instanceof StructureTerminal && target.charge <= 0) return false;
     return target && !!target.store && target.store[RESOURCE_ENERGY];
 };
-action.newTarget = function(creep){
-    const validTargets = [creep.room.storage, creep.room.terminal].filter(this.isValidTarget);
-    return validTargets.length ? _.max(validTargets, 'charge') : null;
+action.newTarget = function(creep) {
+    const terminal = creep.room.terminal;
+    const storage = creep.room.storage;
+    if (terminal && Creep.action.withdrawing.isValidTarget(terminal) && terminal.charge > 1) {
+        return terminal;
+    } else if (terminal || storage) {
+        return _.max([terminal, storage], 'charge');
+    }
+    return false;
 };
 action.work = function(creep){
     return creep.withdraw(creep.target, RESOURCE_ENERGY);
 };
 action.assignDebounce = function(creep, outflowActions) {
-    if (creep.data.lastAction === 'storing' && creep.data.lastTarget === creep.room.storage.id) {
-        // cycle detected
-        const dummyCreep = {
-            carry:{},
-            owner: creep.owner,
-            pos: creep.pos,
-            room: creep.room,
-            sum: creep.carryCapacity
-        };
-        const stored = creep.room.storage.store[RESOURCE_ENERGY];
-        const maxWithdraw = stored > creep.carryCapacity ? creep.carryCapacity : stored;
-        dummyCreep.carry[RESOURCE_ENERGY] = maxWithdraw; // assume we get a full load of energy
-        let target = null;
-        const validAction = _.find(outflowActions, a => {
-            if (a.name !== 'storing' && a.isValidAction(dummyCreep) && a.isAddableAction(dummyCreep)) {
-                target = a.newTarget(dummyCreep);
-                return !!target;
+    const target = action.newTarget(creep);
+    if (target) {
+        if (target instanceof StructureStorage && creep.data.lastAction === 'storing' && creep.data.lastTarget === creep.room.storage.id) {
+            // cycle detected
+            const dummyCreep = {
+                carry:{},
+                owner: creep.owner,
+                pos: creep.pos,
+                room: creep.room,
+                sum: creep.carryCapacity
+            };
+            const stored = creep.room.storage.store[RESOURCE_ENERGY];
+            const maxWithdraw = stored > creep.carryCapacity ? creep.carryCapacity : stored;
+            dummyCreep.carry[RESOURCE_ENERGY] = maxWithdraw; // assume we get a full load of energy
+            let target = null;
+            const validAction = _.find(outflowActions, a => {
+                if (a.name !== 'storing' && a.isValidAction(dummyCreep) && a.isAddableAction(dummyCreep)) {
+                    target = a.newTarget(dummyCreep);
+                    return !!target;
+                }
+                return false;
+            });
+            if (validAction && action.assign(creep, target)) {
+                creep.data.nextAction = validAction.name;
+                creep.data.nextTarget = target.id;
+                return true;
             }
-            return false;
-        });
-        if (validAction && action.assign(creep)) {
-            creep.data.nextAction = validAction.name;
-            creep.data.nextTarget = target.id;
-            return true;
+        } else {
+            return action.assign(creep, target);
         }
-    } else {
-        return action.assign(creep);
     }
     return false;
 };

--- a/creep.action.withdrawing.js
+++ b/creep.action.withdrawing.js
@@ -16,7 +16,7 @@ action.isValidTarget = function(target){
 action.newTarget = function(creep) {
     const terminal = creep.room.terminal;
     const storage = creep.room.storage;
-    if (terminal && Creep.action.withdrawing.isValidTarget(terminal) && terminal.charge > 1) {
+    if (terminal && Creep.action.withdrawing.isValidTarget(terminal)) {
         return terminal;
     } else if (terminal || storage) {
         return _.max([terminal, storage], 'charge');


### PR DESCRIPTION
This change should not be merged until #1249 is resolved as it will drain all terminals down to TERMINAL_STORAGE and put the energy in storage and start a competition between withdraw and reallocating.  However, it does set what I consider to be the correct priority for withdrawing from terminals.