### PR TITLE
actionLastSteps - don't try to travel to range 0 if it's blocked

### DIFF
--- a/creep.Action.js
+++ b/creep.Action.js
@@ -70,7 +70,7 @@ let Action = function(actionName){
                 const targetPos = Traveler.positionAtDirection(creep.pos, direction);
                 if (creep.room.isWalkable(targetPos.x, targetPos.y)) { // low cost last steps if possible
                     creep.move(direction);
-                } else {
+                } else if (!creep.pos.isNearTo(creep.target)) { // travel there if we're not already adjacent
                     creep.travelTo(creep.target, {range: this.reachedRange});
                 }
             }


### PR DESCRIPTION
This only really comes up with the dropping action, since it uses a reachedRange of 0, and we can't change that on a per-instance basis currently.  This prevents Creep.action from trying to travel to range 0 when the target is blocked and the creep is already adjacent.