### PR TITLE
fix action.getStrategy varargs

### DIFF
--- a/creep.Action.js
+++ b/creep.Action.js
@@ -125,9 +125,9 @@ let Action = function(actionName){
     this.selectStrategies = function() {
         return [this.defaultStrategy];
     };
-    this.getStrategy = function(strategyName, creep, args) {
+    this.getStrategy = function(strategyName, creep, ...args) {
         if (_.isUndefined(args)) return creep.getStrategyHandler([this.name], strategyName);
-        else return creep.getStrategyHandler([this.name], strategyName, args);
+        else return creep.getStrategyHandler([this.name], strategyName, ...args);
     };
 };
 module.exports = Action;


### PR DESCRIPTION
this allows more than one argument in the getStrategy convenience method