### PR TITLE
hotfix/populationUndefined - avoid creeps without population entry

### DIFF
--- a/creep.Setup.js
+++ b/creep.Setup.js
@@ -57,7 +57,7 @@ let Setup = function(typeName){
         memory.cost = Creep.bodyCosts(memory.parts);
         memory.mother = spawn.name;
         memory.home = spawn.pos.roomName;
-        for( var son = 1; memory.name == null || Game.creeps[memory.name]; son++ ) {
+        for( var son = 1; memory.name == null || Game.creeps[memory.name] || Memory.population[memory.name]; son++ ) {
             memory.name = this.type + '-' + memory.cost + '-' + son;
         }
         return memory;


### PR DESCRIPTION
This was fixed for tasks, but not for spawns that use setup.  Prevents creeps from taking names of creeps that have died in the same tick.